### PR TITLE
修复控制中心设置主题显示异常的问题

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1622,7 +1622,7 @@ void AppearanceManager::applyGlobalTheme(KeyFile &theme, const QString &themeNam
         }
     };
 
-    setGlobalFile("Wallpaper", TYPEWALLPAPER);
+    setGlobalFile("Wallpaper", TYPEBACKGROUND);
     setGlobalFile("LockBackground", TYPEGREETERBACKGROUND);
     setGlobalItem("IconTheme", TYPEICON);
     setGlobalItem("CursorTheme", TYPECURSOR);


### PR DESCRIPTION
设置主题文件时类型应该使用正确的类型
Log: 修复控制中心改变主题显示异常的问题
Influence: 控制中心主题设置
Bug: https://github.com/linuxdeepin/developer-center/issues/3581

Change-Id: Ib8de54e1577d373d27b4e4d7f2574da674cccfdc