### PR TITLE
chore: remove the notify when start

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -226,7 +226,7 @@ void AppearanceManager::handleSetScaleFactorStarted()
 {
     QString body = tr("Setting display scaling");
     QString summary = tr("Display scaling");
-    dbusProxy->Notify("dde-control-center", "dialog-window-scale", summary, body, {}, {}, 0);
+    qInfo() << body << ":" << summary;
 }
 
 void AppearanceManager::handleSetScaleFactorDone()


### PR DESCRIPTION
Log: remove notify, just print info message

resolve: https://github.com/linuxdeepin/developer-center/issues/3729
设计师觉得第一条通知多于了，而且也没有设置消失的时间。。但是日志还是需要的，所以加了info