### PR TITLE
fix: 调用DBus接口恢复个性化设置失效

### DIFF
--- a/src/service/dbus/appearance1thread.cpp
+++ b/src/service/dbus/appearance1thread.cpp
@@ -208,7 +208,7 @@ QString Appearance1Thread::List(const QString &ty, const QDBusMessage &message)
 void Appearance1Thread::Reset(const QDBusMessage &message)
 {
     QMutexLocker locker(&mutex);
-    QStringList keys{ GSKEYGTKTHEME, GSKEYICONTHEM, GSKEYCURSORTHEME, GSKEYFONTSIZE };
+    QStringList keys{GSKEYGLOBALTHEME, GSKEYGTKTHEME, GSKEYICONTHEM, GSKEYCURSORTHEME, GSKEYFONTSIZE};
 
     appearanceManager->doResetSettingBykeys(keys);
 

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1091,7 +1091,7 @@ bool AppearanceManager::doSetFonts(double size)
         qWarning() << "set font size error:can not set qt theme ";
         return false;
     }
-
+    setFontSize(size);
     return true;
 }
 
@@ -1147,6 +1147,7 @@ bool AppearanceManager::doSetGlobalTheme(QString value)
     } break;
     }
 
+    setGlobalTheme(value);
     return true;
 }
 
@@ -1169,6 +1170,7 @@ bool AppearanceManager::doSetGtkTheme(QString value)
     if (!ddeKWinTheme.isEmpty()) {
         dbusProxy->SetDecorationDeepinTheme(ddeKWinTheme);
     }
+    setGtkTheme(value);
     return subthemes->setGtkTheme(value);
 }
 
@@ -1182,6 +1184,7 @@ bool AppearanceManager::doSetIconTheme(QString value)
         return false;
     }
 
+    setIconTheme(value);
     return setDQtTheme({ QTKEYICON }, { value });
 }
 
@@ -1191,6 +1194,7 @@ bool AppearanceManager::doSetCursorTheme(QString value)
         return false;
     }
 
+    setCursorTheme(value);
     return subthemes->setCursorTheme(value);
 }
 
@@ -1419,7 +1423,7 @@ void AppearanceManager::doResetSettingBykeys(QStringList keys)
 {
     QStringList keyList = settingDconfig.keyList();
     for (auto item : keys) {
-        if (keyList.contains(item)) {
+        if (!keyList.contains(item)) {
             continue;
         }
         settingDconfig.reset(item);


### PR DESCRIPTION
恢复设置后需要更新对应的DBus属性值，让前端去更新界面

Log: 修复调用DBus接口恢复个性化设置失效的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3835
Influence: 控制中心个性化设置