### PR TITLE
fix: wrong format of fontconfig file

### DIFF
--- a/src/service/modules/fonts/fontsmanager.cpp
+++ b/src/service/modules/fonts/fontsmanager.cpp
@@ -361,8 +361,7 @@ QString FontsManager::fontMatch(QString family)
 QString FontsManager::configContent(QString standard, QString monospace)
 {
     QString retString = QString::asprintf(
-    R"(
-<?xml version="1.0"?>
+    R"(<?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
     <match target="pattern">


### PR DESCRIPTION
There shouldn't be empty lines in the front of a xml file. A wrong format will cause fontconfig parsing config files failure, thus a error of font configuration. Trim the first empty line.

Log: fix the wrong format of fontconfig file