### PR TITLE
fix: 切换主题外观桌面壁纸被替换

### DIFF
--- a/src/service/impl/appearancemanager.h
+++ b/src/service/impl/appearancemanager.h
@@ -166,6 +166,7 @@ private:
     QVector<Background> backgroundListVerify(const QVector<Background>& backgrounds);
     QString getWallpaperUri(const QString &index, const QString &monitorName);
     void initGlobalTheme();
+    bool isSkipSetWallpaper(const QString &themePath);
 
 Q_SIGNALS:
     void Changed(const QString &ty, const QString &value);

--- a/src/service/modules/subthemes/customtheme.cpp
+++ b/src/service/modules/subthemes/customtheme.cpp
@@ -24,7 +24,7 @@ CustomTheme::CustomTheme(QObject *parent)
 void CustomTheme::updateValue(const QString &type, const QString &value, const QString &oldTheme, const QVector<QSharedPointer<Theme>> &globalThemes)
 {
     static const QMap<QString, QString> typekeyMap = {
-        { TYPEBACKGROUND, "Wallpaper" },
+        { TYPEWALLPAPER, "Wallpaper" },
         { TYPEGREETERBACKGROUND, "LockBackground" },
         { TYPEICON, "IconTheme" },
         { TYPECURSOR, "CursorTheme" },
@@ -33,9 +33,7 @@ void CustomTheme::updateValue(const QString &type, const QString &value, const Q
         { TYPEMONOSPACEFONT, "MonospaceFont" },
         { TYPEFONTSIZE, "FontSize" },
         { TYPEACTIVECOLOR, "ActiveColor" },
-//        { TYPESTANDARDFONT, "DockBackground" },
         { TYPEDOCKOPACITY, "DockOpacity" },
-//        { TYPESTANDARDFONT, "LauncherOpacity" },
         { TYPWINDOWRADIUS, "WindowRadius" },
         { TYPEWINDOWOPACITY, "WindowOpacity" }
     };


### PR DESCRIPTION
当桌面壁纸为用户自定义的壁纸时, 主题应该切换为自定义主题
当用户去修改主题的其它选项(非壁纸)时, 桌面壁纸不随主题变化

Log: 修复切换主题外观桌面壁纸被替换的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4198