### PR TITLE
chore: update font configuration logic

### DIFF
--- a/src/service/impl/appearancemanager.h
+++ b/src/service/impl/appearancemanager.h
@@ -142,8 +142,6 @@ private:
     void updateNewVersionData();
     void autoSetTheme(double latitude, double longitude);
     void resetThemeAutoTimer();
-    void loadDefaultFontConfig();
-    void getDefaultFonts(QString& standard,QString& monospace);
     void updateThemeAuto(bool enable);
     void enableDetectSysClock(bool enable);
     void updateWSPolicy(QString policy);
@@ -186,7 +184,6 @@ private:
     QSharedPointer<FontsManager>    fontsManager;
     QMap<QString,QString>           monitorMap;
     QMap<QString,coordinate>        coordinateMap;
-    QMap<QString,fontConfigItem>    defaultFontConfigMap;
     double                          longitude;
     double                          latitude;
     QStringList                     desktopBgs;

--- a/src/service/modules/common/commondefine.h
+++ b/src/service/modules/common/commondefine.h
@@ -67,7 +67,6 @@ const QString AppearanceInterface = "org.deepin.dde.Appearance1";
 #define DEFAULTLANGDELIM        "|"
 #define	DEFAULTNAMEDELIM        ","
 #define SPACETYPEMONO           "100"
-#define DEFAULTFONTCONFIGFILE   "/usr/share/deepin-default-settings/fontconfig.json"
 
 #define TYPEGTK                 "gtk"
 #define TYPEICON                "icon"

--- a/src/service/modules/fonts/fontsmanager.cpp
+++ b/src/service/modules/fonts/fontsmanager.cpp
@@ -140,6 +140,17 @@ bool FontsManager::setFamily(QString standard, QString monospace, double size)
     return true;
 }
 
+bool FontsManager::reset()
+{
+    if (!QFile::remove(filePath)) {
+        qWarning() << "failed to remove file " << filePath;
+        return false;
+    }
+
+    xSetting->reset(GSKEYFONTNAME);
+    return true;
+}
+
 QStringList FontsManager::listMonospace()
 {
     QStringList retList;

--- a/src/service/modules/fonts/fontsmanager.h
+++ b/src/service/modules/fonts/fontsmanager.h
@@ -36,6 +36,7 @@ public:
     bool isFontFamily(QString value);
     bool isFontSizeValid(double size);
     bool setFamily(QString standard, QString monospace, double size);
+    bool reset();
     QStringList listMonospace();
     QStringList listStandard();
     QSharedPointer<Family> getFamily(QString id);


### PR DESCRIPTION
Use fontconfig configuration to implement different fonts for different languages instead of regenerating
the fontconfig configuration after switching languages.

When resetting font configuration, directly clear
the user configuration instead of overwriting it
with default values.