### PR TITLE
fix: alpha 升级到beta 设置壁纸白屏

### DIFF
--- a/src/service/modules/dconfig/phasewallpaper.cpp
+++ b/src/service/modules/dconfig/phasewallpaper.cpp
@@ -6,6 +6,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QDebug>
+#include <QFile>
 
 #include <modules/api/utils.h>
 
@@ -169,7 +170,10 @@ QString PhaseWallPaper::getWallpaperUri(const QString &index, const QString &str
             }
 
             if (obj["wpIndex"] == wpIndexKey) {
-                return obj["uri"].toString();
+                auto wallpaper = obj["uri"].toString();
+                auto wallpaperPath = QUrl(wallpaper).toLocalFile();
+                QFile file(wallpaperPath);
+                return file.exists() ? wallpaper : QString();
             }
         }
     }


### PR DESCRIPTION
增加壁纸路径判断,壁纸存在才去设置
防止壁纸丢失时导致的白屏问题

Log: 解决alpha 升级到beta 设置壁纸白屏的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4303