### PR TITLE
fix: 控制中心不显示窗管相关快捷键

### DIFF
--- a/misc/dbusservice/CMakeLists.txt
+++ b/misc/dbusservice/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(DBUS_SERVICE_FILES
+    com.deepin.wm.service
     org.deepin.dde.Appearance1.service
 )
 

--- a/misc/dbusservice/com.deepin.wm.service
+++ b/misc/dbusservice/com.deepin.wm.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=com.deepin.wm
+Exec=/usr/bin/dde-appearance
+SystemdService=dde-appearance.service


### PR DESCRIPTION
提供com.deepin.wm Dbus服务, 防止dde-session-daemon 启动时获取快捷键列表失败

Log: 解决控制中心不显示窗管相关快捷键的问题