### PR TITLE
fix: Add conflicts to solve the problem of file conflicts with dde-kwin during upgrades that cause installation failures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.1) unstable; urgency=medium
+
+  * add Conflicts: dde-kwin.
+
+ -- LiChengGang <lichenggang@uniontech.com>  Tue, 16 May 2023 11:19:58 +0800
+
 dde-appearance (1.1.0) unstable; urgency=medium
 
   * fix: 控制中心不显示窗管相关快捷键

--- a/debian/control
+++ b/debian/control
@@ -30,5 +30,6 @@ Architecture: any
 Depends:
    ${misc:Depends},
    ${shlibs:Depends},
+Conflicts: dde-kwin
 Description: deepin desktop-environment - dde-appearance module
  dde appearance Provides application resource management and control services for the dde desktop environment.


### PR DESCRIPTION
 添加冲突解决升级时与dde-kwin的文件冲突导致安装失败问题

Log:
