### PR TITLE
fix: 自定义主题切换外观主题的其他选项被修改

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -26,7 +26,6 @@
 #include "dbus/appearanceproperty.h"
 #include "dbus/appearancedbusproxy.h"
 
-#include "modules/api/locale.h"
 #include "modules/api/sunrisesunset.h"
 #include "modules/api/themethumb.h"
 #include "modules/dconfig/phasewallpaper.h"
@@ -1570,6 +1569,11 @@ void AppearanceManager::applyGlobalTheme(KeyFile &theme, const QString &themeNam
             doSetByType(type, themeValue);
         }
     };
+
+    // 如果是用户自定义主题, 切换外观时只单独更新外观选项
+    if (themePath.endsWith("custom")) {
+        return setGlobalItem("AppTheme", TYPEGTK);
+    }
 
     setGlobalFile("Wallpaper", TYPEWALLPAPER);
     setGlobalFile("LockBackground", TYPEGREETERBACKGROUND);


### PR DESCRIPTION
用户自定义主题修改的每个选项单独生效, 不影响主题的其他选项

Log: 修复自定义主题切换外观主题的其他选项被修改的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4395