### PR TITLE
fix: set theme by dde-control-center will cause splash screen problem

### DIFF
--- a/src/service/dbus/deepinwmfaker.cpp
+++ b/src/service/dbus/deepinwmfaker.cpp
@@ -929,8 +929,6 @@ void DeepinWMFaker::SetDecorationTheme(const QString &type, const QString &name)
     m_kwinConfig->group("deepin-chameleon").writeEntry("theme", type + "/" + name);
 
     syncConfigForKWin();
-    QDBusInterface interface_kwin(KWinDBusService, KWinDBusPath, KWinDBusInterface);
-    interface_kwin.call("reconfigure");
 }
 
 void DeepinWMFaker::SetDecorationDeepinTheme(const QString &name)


### PR DESCRIPTION
call kwin reconfigure interface will cause splash screen problem

Log: fix splash screen problem