### PR TITLE
fix: 使用实际的图片路径(地址)设置壁纸

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ dde-appearance (1.1.3) unstable; urgency=medium
   * fix: wayland can't set wallpaper
   * fix: fix: background should refresh after set background
 
- -- dengbo <dengbo@deepin.org>  Wed, 05 July 2023 11:08:40 +0800
+ -- dengbo <dengbo@deepin.org>  Wed, 05 Jul 2023 11:08:40 +0800
 
 dde-appearance (1.1.2) unstable; urgency=medium
 

--- a/src/service/modules/background/backgrounds.cpp
+++ b/src/service/modules/background/backgrounds.cpp
@@ -225,5 +225,5 @@ QString Backgrounds::prepare(QString file)
         return tempFile;
     }
 
-    return onPrepare(file);
+    return onPrepare(tempFile);
 }


### PR DESCRIPTION
不应该使用图片url, 需要使用解析后的图片地址转换为壁纸图片去设置

Log: 修复看图设置壁纸错误的问题
Influence: 桌面壁纸设置
Resolve: https://github.com/linuxdeepin/developer-center/issues/5021