### PR TITLE
fix: 使用实际的图片路径(地址)设置壁纸

### DIFF
--- a/src/service/modules/background/backgrounds.cpp
+++ b/src/service/modules/background/backgrounds.cpp
@@ -225,5 +225,5 @@ QString Backgrounds::prepare(QString file)
         return tempFile;
     }
 
-    return onPrepare(file);
+    return onPrepare(tempFile);
 }


### PR DESCRIPTION
不应该使用图片url, 需要使用解析后的图片地址转换为壁纸图片去设置

Log: 修复看图设置壁纸错误的问题
Influence: 桌面壁纸设置
resolve: https://github.com/linuxdeepin/developer-center/issues/5021