### PR TITLE
chore: auto set theme feature is missing

### DIFF
--- a/misc/systemd/dde-appearance.service.in
+++ b/misc/systemd/dde-appearance.service.in
@@ -12,6 +12,3 @@ Before=dde-session-initialized.target
 Type=dbus
 BusName=org.deepin.dde.Appearance1
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-appearance
-
-[Install]
-WantedBy=graphical-session.target

--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -16,12 +16,11 @@ AppearanceDBusProxy::AppearanceDBusProxy(QObject *parent)
     , m_displayInterface(new DDBusInterface("org.deepin.dde.Display1", "/org/deepin/dde/Display1", "org.deepin.dde.Display1", QDBusConnection::sessionBus(), this))
     , m_xSettingsInterface(new DDBusInterface("org.deepin.dde.XSettings1", "/org/deepin/dde/XSettings1", "org.deepin.dde.XSettings1", QDBusConnection::sessionBus(), this))
     , m_timeDateInterface(new DDBusInterface("org.freedesktop.timedate1", "/org/freedesktop/timedate1", "org.freedesktop.timedate1", QDBusConnection::systemBus(), this))
-    , m_sessionTimeDateInterface(new DDBusInterface("org.deepin.dde.Timedate1", "/org/deepin/dde/Timedate1", "org.deepin.dde.Timedate1", QDBusConnection::sessionBus(), this))
     , m_nid(0)
 {
     registerScaleFactorsMetaType();
-    m_sessionTimeDateInterface->setSuffix("Session");
     QDBusConnection::systemBus().connect(DaemonService, DaemonPath, DaemonInterface, "HandleForSleep", this, SIGNAL(HandleForSleep(bool)));
+    QDBusConnection::sessionBus().connect(QStringLiteral("org.deepin.dde.Timedate1"), QStringLiteral("/org/deepin/dde/Timedate1"), QStringLiteral("org.deepin.dde.Timedate1"), "TimeUpdate", this, SIGNAL(TimeUpdate()));
 }
 
 void AppearanceDBusProxy::setUserInterface(const QString &userPath)
@@ -172,12 +171,7 @@ bool AppearanceDBusProxy::nTP()
 {
     return qvariant_cast<bool>(m_timeDateInterface->property("NTP"));
 }
-// sessionTimeDateInterface
-bool AppearanceDBusProxy::nTPSession()
-{
 
-    return qvariant_cast<bool>(m_sessionTimeDateInterface->property("NTPSession"));
-}
 // imageBlurInterface
 void AppearanceDBusProxy::Delete(const QString &file)
 {

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -99,14 +99,9 @@ Q_SIGNALS:
     void TimezoneChanged(QString timezone);
     void NTPChanged(bool NTP);
 
-    // sessionTimeDateInterface
 public:
-    Q_PROPERTY(bool NTPSession READ nTPSession NOTIFY NTPSessionChanged)
-    bool nTPSession();
-
 Q_SIGNALS:
     void TimeUpdate();
-    void NTPSessionChanged();
 
     // imageBlurInterface
 public:
@@ -132,7 +127,6 @@ private:
     DDBusInterface *m_displayInterface;
     DDBusInterface *m_xSettingsInterface;
     DDBusInterface *m_timeDateInterface;
-    DDBusInterface *m_sessionTimeDateInterface;
     QSharedPointer<DDBusInterface> m_userInterface;
     uint m_nid;
 };


### PR DESCRIPTION
dde-appearance depends org.deepin.dde.Timedate1(dde-session-daemon) service so it must depends org.dde.session.Daemon1.service

Log: