### PR TITLE
fix: Cursor image not scaled to same size

### DIFF
--- a/src/service/modules/api/themethumb.cpp
+++ b/src/service/modules/api/themethumb.cpp
@@ -259,7 +259,7 @@ QVector<QImage*> getCursors(QString dir, int size)
             {
                 if(image->width() != size)
                 {
-                    image->scaled(size,image->height());
+                    *image = image->scaledToWidth(size);
                 }
                 images.push_back(image);
                 break;


### PR DESCRIPTION
The scaled images were not updated to cursor image list.

Issue: https://github.com/linuxdeepin/developer-center/issues/9892
Log: Cursor image not scaled to same size