### PR TITLE
chore: 解决开机壁纸自动变更的问题

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1765,6 +1765,10 @@ void AppearanceManager::initGlobalTheme()
         } else {
             setGlobalTheme(DEFAULTGLOBALTHEME);
         }
+    } else {
+        // 初始化m_currentGlobalTheme
+        if (m_currentGlobalTheme.isEmpty())
+            doSetGlobalTheme(globalID);
     }
 }
 


### PR DESCRIPTION
m_currentGlobalTheme未初始化，导致在appearance定时器触发时，重新设置了壁纸。