### PR TITLE
chore: 解决快捷键无法恢复的问题

### DIFF
--- a/fakewm/dbus/deepinwmfaker.cpp
+++ b/fakewm/dbus/deepinwmfaker.cpp
@@ -707,7 +707,7 @@ static QMap<QString, QList<QKeySequence>> getShoutcutListFromKDEConfigFile()
 {
     // 认为系统配置文件中存储的快捷键为默认值
     KConfig kglobalshortcutsrc("/etc/xdg/kglobalshortcutsrc");
-    KConfigGroup kwin(&kglobalshortcutsrc, "deepin-kwin");
+    KConfigGroup kwin(&kglobalshortcutsrc, "kwin");
 
     if (!kwin.isValid())
         return {};


### PR DESCRIPTION
kwin升级后，快捷键的配置中group应该是kwin
Issue: https://github.com/linuxdeepin/developer-center/issues/10292