### PR TITLE
Revert "chore: 解决快捷键无法恢复的问题"

### DIFF
--- a/fakewm/dbus/deepinwmfaker.cpp
+++ b/fakewm/dbus/deepinwmfaker.cpp
@@ -707,7 +707,7 @@ static QMap<QString, QList<QKeySequence>> getShoutcutListFromKDEConfigFile()
 {
     // 认为系统配置文件中存储的快捷键为默认值
     KConfig kglobalshortcutsrc("/etc/xdg/kglobalshortcutsrc");
-    KConfigGroup kwin(&kglobalshortcutsrc, "kwin");
+    KConfigGroup kwin(&kglobalshortcutsrc, "deepin-kwin");
 
     if (!kwin.isValid())
         return {};


### PR DESCRIPTION
由于group变更导致快捷键丢失问题，kwin设置快捷键的group已经还原到之前的deepin-kwin 
This reverts commit 314539ac37e309af0b9ce4194e7b4a1afe84ca68.