### PR TITLE
feat: Use string to store Compact_Font_Size in dconfig

### DIFF
--- a/misc/dconfig/org.deepin.dde.appearance.json
+++ b/misc/dconfig/org.deepin.dde.appearance.json
@@ -173,7 +173,7 @@
             "visibility": "private"
         },
         "Compact_Font_Size": {
-            "value": 9.0,
+            "value": "9.0",
             "serial": 0,
             "flags": [],
             "name": "Compact_Font_Size",

--- a/src/service/dbus/appearance1thread.cpp
+++ b/src/service/dbus/appearance1thread.cpp
@@ -30,7 +30,13 @@ Appearance1Thread::Appearance1Thread()
     property->monospaceFont.init(settingDconfig.value(GSKEYFONTMONOSPACE).toString());
     property->dtkSizeMode.init(settingDconfig.value(DDTKSIZEMODE).toInt());
     // dtkSizeMode必须先于fontSize初始化，紧凑模式下，使用Compact_Font_Size配置
-    property->fontSize.init(settingDconfig.value(property->dtkSizeMode == 1 ? DCOMPACTFONTSIZE : GSKEYFONTSIZE).toDouble());
+    bool getFontSizeSuc = false;
+    settingDconfig.value(DCOMPACTFONTSIZE).toDouble(&getFontSizeSuc);
+    if (!getFontSizeSuc) {
+        settingDconfig.reset(DCOMPACTFONTSIZE);
+    }
+    double fontSize = settingDconfig.value(property->dtkSizeMode == 1 ? DCOMPACTFONTSIZE : GSKEYFONTSIZE).toDouble(&getFontSizeSuc);
+    property->fontSize.init(getFontSizeSuc ? fontSize : 9.0);
     property->opacity.init(settingDconfig.value(GSKEYOPACITY).toDouble());
     property->wallpaperSlideShow.init(settingDconfig.value(GSKEYWALLPAPERSLIDESHOW).toString());
     property->wallpaperURls.init(settingDconfig.value(GSKEYWALLPAPERURIS).toString());

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -514,7 +514,11 @@ void AppearanceManager::setFontSize(double value)
     }
 
     if (m_settingDconfig.isValid() && !qFuzzyCompare(value, m_property->fontSize)) {
-        m_settingDconfig.setValue(m_property->dtkSizeMode == 1 ? DCOMPACTFONTSIZE : GSKEYFONTSIZE, value);
+        if (m_property->dtkSizeMode == 1) {
+            m_settingDconfig.setValue(DCOMPACTFONTSIZE, QString::number(value, 'g'));
+        } else {
+            m_settingDconfig.setValue(GSKEYFONTSIZE, value);
+        }
         m_property->fontSize = value;
         updateCustomTheme(TYPEFONTSIZE, QString::number(value));
     }


### PR DESCRIPTION
When the initial value is 9.0, Dconfig will incorrectly parse to int type, resulting in subsequent failure to set as a floating point number

Log: