### PR TITLE
chore: 解决控制中心个性化中主题图片加载不出来的问题

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1312,7 +1312,13 @@ QString AppearanceManager::doGetWallpaperSlideShow(QString monitorName)
 
 double AppearanceManager::getScaleFactor()
 {
-    double scaleFactor = m_dbusProxy->GetScaleFactor();
+    double scaleFactor = 0.0;
+    if (QGSettings::isSchemaInstalled(XSETTINGSSCHEMA)) {
+        QGSettings xSetting(XSETTINGSSCHEMA);
+        scaleFactor = xSetting.get("scale-factor").toDouble();
+    } else {
+        scaleFactor = m_dbusProxy->GetScaleFactor();
+    }
     qInfo() << __FUNCTION__ << "UpdateScaleFactor" << scaleFactor;
     UpdateScaleFactor(scaleFactor);
     return scaleFactor;


### PR DESCRIPTION
插件启动太早，比startdde都早，所以通过xsetting获取不到scale，直接通过gsetting获取缩放。