### PR TITLE
fix: Quickly adjusting transparency may cause it to get stuck

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -59,6 +59,7 @@ AppearanceManager::AppearanceManager(AppearanceProperty *prop, QObject *parent)
     , m_customTheme(new CustomTheme())
     , m_globalThemeUpdating(false)
     , m_wallpaperConfig({})
+    , m_opacityTriggerTimer(new QTimer(this))
 {
     if (QGSettings::isSchemaInstalled(XSETTINGSSCHEMA)) {
         m_xSetting = QSharedPointer<QGSettings>(new QGSettings(XSETTINGSSCHEMA));
@@ -91,6 +92,11 @@ bool AppearanceManager::init()
     initCoordinate();
     initUserObj();
     initCurrentBgs();
+
+    m_opacityTriggerTimer->setSingleShot(true);
+    m_opacityTriggerTimer->setInterval(100);
+
+    connect(m_opacityTriggerTimer, &QTimer::timeout, this, &AppearanceManager::onOpacityTriggerTimeout);
 
     connect(m_dbusProxy.get(), &AppearanceDBusProxy::workspaceCountChanged, this, &AppearanceManager::handleWmWorkspaceCountChanged);
     connect(m_dbusProxy.get(), &AppearanceDBusProxy::SetScaleFactorStarted, this, &AppearanceManager::handleSetScaleFactorStarted);
@@ -610,10 +616,18 @@ void AppearanceManager::setWindowRadius(int value)
 
 void AppearanceManager::setOpacity(double value)
 {
-    if (m_settingDconfig.isValid() && !qFuzzyCompare(value, m_property->opacity)) {
-        m_settingDconfig.setValue(GSKEYOPACITY, value);
-        m_property->opacity = value;
-        updateCustomTheme(TYPEWINDOWOPACITY, QString::number(value));
+    m_tmpOpacity = value;
+    if (!m_opacityTriggerTimer->isActive()) {
+        m_opacityTriggerTimer->start();
+    }
+}
+
+void AppearanceManager::onOpacityTriggerTimeout()
+{
+    if (m_settingDconfig.isValid() && !qFuzzyCompare(m_tmpOpacity, m_property->opacity)) {
+        m_settingDconfig.setValue(GSKEYOPACITY, m_tmpOpacity);
+        m_property->opacity = m_tmpOpacity;
+        updateCustomTheme(TYPEWINDOWOPACITY, QString::number(m_tmpOpacity));
     }
 }
 

--- a/src/service/impl/appearancemanager.h
+++ b/src/service/impl/appearancemanager.h
@@ -140,6 +140,7 @@ public Q_SLOTS:
     void handleGlobalThemeChangeTimeOut();
     void updateMonitorMap();
     void handlePrepareForSleep(bool sleep);
+    void onOpacityTriggerTimeout();
 
 private:
     void initCoordinate();
@@ -216,6 +217,8 @@ private:
     bool                                             m_globalThemeUpdating;
     QString                                          m_currentGlobalTheme; // 当前主题，globalTheme+.light/.dark
     QJsonArray                                       m_wallpaperConfig; // store the config
+    QTimer                                           *m_opacityTriggerTimer; // 定时器限制opacity的变化速率，防止卡顿
+    double                                           m_tmpOpacity;
 };
 
 #endif // APPEARANCEMANAGER_H


### PR DESCRIPTION
deepin-kwin的模糊处理会监听opacity,频繁变化会导致kwin卡死，在这里做一下频率变化的限制，同时已通知deepin-kwin处理opacity快速变化导致的卡死问题

Bug: https://pms.uniontech.com/bug-view-286305.html