### PR TITLE
fix: active color are invalid in different global theme

### DIFF
--- a/src/service/dbus/appearance1thread.cpp
+++ b/src/service/dbus/appearance1thread.cpp
@@ -39,7 +39,7 @@ Appearance1Thread::Appearance1Thread()
         property->windowRadius.init(xSetting.get(GSKEYDTKWINDOWRADIUS).toInt());
         QString activeColor = settingDconfig.value(GSKEYGLOBALTHEME).toString().endsWith("dark") ?
             xSetting.get(GSKEYQTACTIVECOLOR_DARK).toString() : xSetting.get(GSKEYQTACTIVECOLOR).toString();
-        property->qtActiveColor.init(AppearanceManager::qtActiveColorToHexColor(xSetting.get(GSKEYQTACTIVECOLOR).toString()));
+        property->qtActiveColor.init(AppearanceManager::qtActiveColorToHexColor(activeColor));
     }
     if (QGSettings::isSchemaInstalled(WRAPBGSCHEMA)) {
         QGSettings wrapBgSetting(WRAPBGSCHEMA);

--- a/src/service/modules/subthemes/customtheme.cpp
+++ b/src/service/modules/subthemes/customtheme.cpp
@@ -72,6 +72,14 @@ void CustomTheme::updateValue(const QString &type, const QString &value, const Q
         Q_EMIT updateToCustom(modeStr);
     }
 
+    if (type == TYPEACTIVECOLOR) {
+        QStringList colors = value.split(',');
+        m_customTheme->setKey("DefaultTheme", typekeyMap.value(type), colors.value(0));
+        m_customTheme->setKey("DarkTheme", typekeyMap.value(type), colors.value(1));
+        saveCustomTheme();
+        return;
+    }
+
     if (mode & Light)
         m_customTheme->setKey("DefaultTheme", typekeyMap.value(type), value);
     if (mode & Dark)


### PR DESCRIPTION
set the light and dark color to gsettings and dconfig when selecting a global theme

pms: BUG-291243