### PR TITLE
fix: active color are invalid in different global theme

### DIFF
--- a/src/service/dbus/appearance1thread.cpp
+++ b/src/service/dbus/appearance1thread.cpp
@@ -38,7 +38,7 @@ Appearance1Thread::Appearance1Thread()
         property->windowRadius.init(xSetting.get(GSKEYDTKWINDOWRADIUS).toInt());
         QString activeColor = settingDconfig.value(GSKEYGLOBALTHEME).toString().endsWith("dark") ?
             xSetting.get(GSKEYQTACTIVECOLOR_DARK).toString() : xSetting.get(GSKEYQTACTIVECOLOR).toString();
-        property->qtActiveColor.init(AppearanceManager::qtActiveColorToHexColor(xSetting.get(GSKEYQTACTIVECOLOR).toString()));
+        property->qtActiveColor.init(AppearanceManager::qtActiveColorToHexColor(activeColor));
     }
     if (QGSettings::isSchemaInstalled(WRAPBGSCHEMA)) {
         QGSettings wrapBgSetting(WRAPBGSCHEMA);

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -324,7 +324,6 @@ void AppearanceManager::handleSettingDConfigChange(QString key)
             }
             bSuccess = doSetGlobalTheme(value);
             if (bSuccess) {
-                setQtActiveColor("");
                 setGlobalTheme(value);
             }
         } else if (key == GSKEYGTKTHEME) {
@@ -619,12 +618,13 @@ void AppearanceManager::onOpacityTriggerTimeout()
 
 void AppearanceManager::setQtActiveColor(const QString &value)
 {
-    if (value != m_property->qtActiveColor && m_xSetting) {
-        QStringList colors = m_settingDconfig.value(DACTIVECOLORS).toString().split(',');
-        QString result = m_settingDconfig.value(GSKEYGLOBALTHEME).toString().endsWith("dark") ?
-            colors.value(1) : colors.value(0);
+    Q_UNUSED(value)
+    QString activeColors = m_settingDconfig.value(DACTIVECOLORS).toString();
+    QStringList colors = activeColors.split(',');
+    QString result = m_currentGlobalTheme.endsWith("dark") ? colors.value(1) : colors.value(0);
+    if (result != m_property->qtActiveColor && m_xSetting) {
         m_property->qtActiveColor = result;
-        updateCustomTheme(TYPEACTIVECOLOR, result);
+        updateCustomTheme(TYPEACTIVECOLOR, activeColors);
     }
 }
 
@@ -1164,11 +1164,22 @@ bool AppearanceManager::doSetGlobalTheme(QString value)
     KeyFile theme(',');
     theme.loadFile(themePath + "/index.theme");
     QString defaultTheme = theme.getStr("Deepin Theme", "DefaultTheme");
-    if (defaultTheme.isEmpty())
+    QString lightActiveColor;
+    if (defaultTheme.isEmpty()) {
         return false;
+    } else {
+        lightActiveColor = theme.getStr(defaultTheme, "ActiveColor");
+    }
+
     QString darkTheme = theme.getStr("Deepin Theme", "DarkTheme");
-    if (darkTheme.isEmpty())
+    QString darkActiveColor;
+    if (darkTheme.isEmpty()) {
         mode = Light;
+    } else {
+        darkActiveColor = theme.getStr(darkTheme, "ActiveColor", lightActiveColor);
+    }
+
+    setActiveColors(lightActiveColor + "," + darkActiveColor);
 
     m_currentGlobalTheme = value;
     switch (mode) {
@@ -1677,7 +1688,9 @@ void AppearanceManager::applyGlobalTheme(KeyFile &theme, const QString &themeNam
 
     // 如果是用户自定义主题, 切换外观时只单独更新外观选项
     if (themePath.endsWith("custom")) {
-        return setGlobalItem("AppTheme", TYPEGTK);
+        setGlobalItem("AppTheme", TYPEGTK);
+        m_globalThemeUpdating = false;
+        return;
     }
 
     setGlobalFile("Wallpaper", TYPEWALLPAPER);

--- a/src/service/modules/subthemes/customtheme.cpp
+++ b/src/service/modules/subthemes/customtheme.cpp
@@ -72,6 +72,14 @@ void CustomTheme::updateValue(const QString &type, const QString &value, const Q
         Q_EMIT updateToCustom(modeStr);
     }
 
+    if (type == TYPEACTIVECOLOR) {
+        QStringList colors = value.split(',');
+        m_customTheme->setKey("DefaultTheme", typekeyMap.value(type), colors.value(0));
+        m_customTheme->setKey("DarkTheme", typekeyMap.value(type), colors.value(1));
+        saveCustomTheme();
+        return;
+    }
+
     if (mode & Light)
         m_customTheme->setKey("DefaultTheme", typekeyMap.value(type), value);
     if (mode & Dark)


### PR DESCRIPTION
set the light and dark color to gsettings and dconfig when selecting a global theme

pms: BUG-291243