### PR TITLE
fix: 修复系统安装完成后无法进入桌面。输入密码后一直处于加载状态

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.41) unstable; urgency=medium
+
+  * fix: solve the problem of slow entry to the desktop
+
+ -- Chengqi E <echengqi@uniontech.com>  Mon, 09 Dec 2024 13:30:49 +0800
+
 dde-appearance (1.1.40) unstable; urgency=medium
 
   * fix: the wallpaper list may not exist

--- a/misc/systemd/dde-fakewm.service.in
+++ b/misc/systemd/dde-fakewm.service.in
@@ -2,7 +2,6 @@
 Description=dde window manager
 
 Requisite=plasma-kglobalaccel.service
-After=dde-session-pre.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
拉起dde-fakewm,需要先拉起de-session-pre.target,de-session-pre.target需要重新拉起startdde,导致循环依赖

pms: BUG-292895