### PR TITLE
fix: Quickly adjusting transparency may cause it to get stuck

### DIFF
--- a/src/service/impl/appearancemanager.h
+++ b/src/service/impl/appearancemanager.h
@@ -139,6 +139,7 @@ public Q_SLOTS:
     void handleGlobalThemeChangeTimeOut();
     void updateMonitorMap();
     void handlePrepareForSleep(bool sleep);
+    void onOpacityTriggerTimeout();
 
 private:
     void initCoordinate();
@@ -215,6 +216,8 @@ private:
     bool                                             m_globalThemeUpdating;
     QString                                          m_currentGlobalTheme; // 当前主题，globalTheme+.light/.dark
     QJsonArray                                       m_wallpaperConfig; // store the config
+    QTimer                                           *m_opacityTriggerTimer; // 定时器限制opacity的变化速率，防止卡顿
+    double                                           m_tmpOpacity;
 };
 
 #endif // APPEARANCEMANAGER_H


### PR DESCRIPTION
deepin-kwin的模糊处理会监听opacity,频繁变化会导致kwin卡死，在这里做一下频率变化的限制，同时已通知deepin-kwin处理opacity快速变化导致的卡死问题 延时增加到200ms

pms: BUG-289531