### PR TITLE
feat: refresh the font list when calling the list method

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1234,8 +1234,10 @@ QString AppearanceManager::doList(QString type)
     } else if (type == TYPEBACKGROUND) {
         return marshal(backgroundListVerify(m_backgrounds->listBackground()));
     } else if (type == TYPESTANDARDFONT) {
+        m_fontsManager->refreshFamilyList();
         return marshal(m_fontsManager->listStandard());
     } else if (type == TYPEMONOSPACEFONT) {
+        m_fontsManager->refreshFamilyList();
         return marshal(m_fontsManager->listMonospace());
     } else if (type == TYPEGLOBALTHEME) {
         return marshal(m_subthemes->listGlobalThemes());

--- a/src/service/modules/common/commondefine.h
+++ b/src/service/modules/common/commondefine.h
@@ -116,6 +116,9 @@ extern QDBusConnection *pluginDbus;
 #define WSPOLICYLOGIN           "login"
 #define	WSPOLICYWAKEUP          "wakeup"
 
+#define FONTCACHEDIR            utils::GetUserHomeDir() + "/.cache/deepin/dde-daemon/fonts"
+#define FONTCACHEFILE           "family_table"
+
 #define HOME "HOME"
 
 #define MAX_FILEPATH_LEN 256

--- a/src/service/modules/fonts/fontsmanager.h
+++ b/src/service/modules/fonts/fontsmanager.h
@@ -42,7 +42,7 @@ public:
     using IrregularFontOverrideMap = QMap<QString, IrregularFontOverride>;
 public:
     FontsManager();
-    void initFamily();
+    void refreshFamilyList();
     bool isFontFamily(QString value);
     bool isFontSizeValid(double size);
     bool setFamily(QString standard, QString monospace, double size);
@@ -77,7 +77,6 @@ private:
     QString                                 filePath;
     QMap<QString,QSharedPointer<Family>>    familyMap;
     QStringList                             familyBlacklist;
-    QString                                 fileName;
     IrregularFontOverrideMap                irregularFontOverrideMap;
     QScopedArrayPointer<DConfig>            appearanceConfig;
 };


### PR DESCRIPTION
Fix that the font list displayed in dde-control-center cannot be refreshed after installing or removing fonts

pms: BUG-288683

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the font list in dde-control-center was not refreshing after fonts were installed or removed.