### PR TITLE
chore: bump version to 1.1.49

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-appearance (1.1.49) unstable; urgency=medium
+
+  * feat: refresh the font list when calling the list method
+  * feat: Add override font to support language functionality
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 27 Feb 2025 21:56:09 +0800
+
 dde-appearance (1.1.48) unstable; urgency=medium
 
   * feat: remove wallpaper slideshow


### PR DESCRIPTION
as title

Log: bump version to 1.1.49

## Summary by Sourcery

Chores:
- Bump version to 1.1.49.