### PR TITLE
chore: bump version to 1.1.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.50) unstable; urgency=medium
+
+  * chore: adapt to qt6
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 07 Mar 2025 14:57:51 +0800
+
 dde-appearance (1.1.49) unstable; urgency=medium
 
   * feat: refresh the font list when calling the list method


### PR DESCRIPTION
as title

Log: bump version to 1.1.50

## Summary by Sourcery

Chores:
- Bump version to 1.1.50.