### PR TITLE
fix: DBus local mutual call failed

### DIFF
--- a/src/service/dbus/appearance1.cpp
+++ b/src/service/dbus/appearance1.cpp
@@ -4,7 +4,6 @@
 
 #include "appearance1.h"
 #include "appearance1thread.h"
-#include "modules/common/commondefine.h"
 
 #include <QDBusMessage>
 
@@ -148,65 +147,45 @@ void Appearance1::Delete(const QString &ty, const QString &name)
 }
 
 QString Appearance1::GetCurrentWorkspaceBackground()
-{ 
-    auto message = this->message();
-    setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetCurrentWorkspaceBackground", Qt::QueuedConnection, Q_ARG(QDBusMessage, message));
-    return QString();
+{
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetCurrentWorkspaceBackground(message());
 }
 
 QString Appearance1::GetCurrentWorkspaceBackgroundForMonitor(const QString &strMonitorName)
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetCurrentWorkspaceBackgroundForMonitor", Qt::QueuedConnection, Q_ARG(QString, strMonitorName), Q_ARG(QDBusMessage, message));
-    return QString();
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetCurrentWorkspaceBackgroundForMonitor(strMonitorName, message());
 }
 
 double Appearance1::GetScaleFactor()
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetScaleFactor", Qt::QueuedConnection, Q_ARG(QDBusMessage, message));
-    return 0.0;
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetScaleFactor(message());
 }
 
 ScaleFactors Appearance1::GetScreenScaleFactors()
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetScreenScaleFactors", Qt::QueuedConnection, Q_ARG(QDBusMessage, message));
-    return ScaleFactors();
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetScreenScaleFactors(message());
 }
 
 QString Appearance1::GetActiveColors()
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetActiveColors", Qt::QueuedConnection, Q_ARG(QDBusMessage, message));
-    return QString();
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetActiveColors(message());
 }
 
 QString Appearance1::GetWallpaperSlideShow(const QString &monitorName)
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetWallpaperSlideShow", Qt::QueuedConnection, Q_ARG(QString, monitorName), Q_ARG(QDBusMessage, message));
-    return QString();
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetWallpaperSlideShow(monitorName, message());
 }
 
 QString Appearance1::GetWorkspaceBackgroundForMonitor(const int &index, const QString &strMonitorName)
 {
-    auto message = this->message();
-    setDelayedReply(true);
-    message.setDelayedReply(true);
-    QMetaObject::invokeMethod(appearance1Thread.get(), "GetWorkspaceBackgroundForMonitor", Qt::QueuedConnection, Q_ARG(int, index), Q_ARG(QString, strMonitorName), Q_ARG(QDBusMessage, message));
-    return QString();
+    setDelayedReply(false);
+    return appearance1Thread.get()->GetWorkspaceBackgroundForMonitor(index, strMonitorName, message());
 }
 
 QString Appearance1::List(const QString &ty)

--- a/src/service/dbus/appearance1thread.cpp
+++ b/src/service/dbus/appearance1thread.cpp
@@ -182,51 +182,51 @@ void Appearance1Thread::Delete(const QString &ty, const QString &name, const QDB
 
 QString Appearance1Thread::GetCurrentWorkspaceBackground(const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(appearanceManager->doGetCurrentWorkspaceBackground()));
-    return QString();
+    return appearanceManager->doGetCurrentWorkspaceBackground();
 }
 
 QString Appearance1Thread::GetCurrentWorkspaceBackgroundForMonitor(const QString &strMonitorName, const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(appearanceManager->doGetCurrentWorkspaceBackgroundForMonitor(strMonitorName)));
-    return QString();
+    return appearanceManager->doGetCurrentWorkspaceBackgroundForMonitor(strMonitorName);
 }
 
 double Appearance1Thread::GetScaleFactor(const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(appearanceManager->getScaleFactor()));
-    return 0.0;
+    return appearanceManager->getScaleFactor();
 }
 
 ScaleFactors Appearance1Thread::GetScreenScaleFactors(const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(QVariant::fromValue(appearanceManager->getScreenScaleFactors())));
-    return ScaleFactors();
+    return appearanceManager->getScreenScaleFactors();
 }
 
 QString Appearance1Thread::GetActiveColors(const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(QVariant::fromValue(appearanceManager->getActiveColors())));
-    return QString();
+    return appearanceManager->getActiveColors();
 }
 
 QString Appearance1Thread::GetWallpaperSlideShow(const QString &monitorName, const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(appearanceManager->doGetWallpaperSlideShow(monitorName)));
-    return QString();
+    return appearanceManager->doGetWallpaperSlideShow(monitorName);
 }
 
 QString Appearance1Thread::GetWorkspaceBackgroundForMonitor(const int &index, const QString &strMonitorName, const QDBusMessage &message)
 {
+    Q_UNUSED(message);
     QMutexLocker locker(&mutex);
-    APPEARANCEDBUS.send(message.createReply(appearanceManager->doGetWorkspaceBackgroundForMonitor(index, strMonitorName)));
-    return QString();
+    return appearanceManager->doGetWorkspaceBackgroundForMonitor(index, strMonitorName);
 }
 
 QString Appearance1Thread::List(const QString &ty, const QDBusMessage &message)


### PR DESCRIPTION
When calling dbus locally and declaring a delayed call, the call will fail. See https://github.com/deepin-community/qt6-base/blob/e4c2535d5c7360495138f187c97bc2c4eaae4fa7/src/dbus/qdbusintegrator.cpp#L1017

Partial calls return directly without delay

pms: BUG-306247

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where local DBus calls with a declared delay would fail.