### PR TITLE
fix: no serif font config was generated when setting font

### DIFF
--- a/src/service/modules/fonts/fontsmanager.cpp
+++ b/src/service/modules/fonts/fontsmanager.cpp
@@ -375,6 +375,15 @@ QString FontsManager::configContent(QString standard, QString monospace)
 <fontconfig>
     <match target="pattern">
         <test qual="any" name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>%s</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test qual="any" name="family">
             <string>sans-serif</string>
         </test>
         <edit name="family" mode="prepend" binding="strong">
@@ -395,6 +404,7 @@ QString FontsManager::configContent(QString standard, QString monospace)
         <edit name="rgba"><const>rgb</const></edit>
     </match>
  </fontconfig>)",
+    standard.toLatin1().data(),
     standard.toLatin1().data(),
     monospace.toLatin1().data());
     return retString;


### PR DESCRIPTION
Add write serif font config to ensure normal display

pms: BUG-307225
pms: BUG-306929

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where no serif font config was generated when setting the font, ensuring normal display.