### PR TITLE
fix: no cursor theme given to kwin

### DIFF
--- a/src/service/modules/api/themes.cpp
+++ b/src/service/modules/api/themes.cpp
@@ -266,6 +266,7 @@ bool ThemesApi::setCursorTheme(QString name)
 
     setQtCursor(name);
     setGtkCursor(name);
+    setWMCursor(name);
 
     return true;
 }
@@ -693,6 +694,10 @@ void ThemesApi::setQtCursor(QString name)
 #endif
 }
 
+void ThemesApi::setWMCursor(QString name)
+{
+    dbusProxy->setcursorTheme(name);
+}
 
 QString ThemesApi::getGtk2ConfFile()
 {

--- a/src/service/modules/api/themes.h
+++ b/src/service/modules/api/themes.h
@@ -58,6 +58,7 @@ public:
     bool setDefaultCursor(QString name);
     void setGtkCursor(QString name);
     void setQtCursor(QString name);
+    void setWMCursor(QString name);
 
 private:
     QString getGtk2ConfFile();


### PR DESCRIPTION
as title

pmg: BUG-308577

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the cursor theme was not being applied to KWin.