### PR TITLE
chore: bump version to 1.1.54

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.54) unstable; urgency=medium
+
+  * fix: no cursor theme given to kwin
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 20 Mar 2025 17:57:16 +0800
+
 dde-appearance (1.1.53) unstable; urgency=medium
 
   * fix: no serif font config was generated when setting font


### PR DESCRIPTION
as title

Log: bump version to 1.1.54

## Summary by Sourcery

Chores:
- Bump version to 1.1.54.