### PR TITLE
feat(cursor): when name is not read, fallback to id

### DIFF
--- a/src/service/modules/subthemes/subthemes.cpp
+++ b/src/service/modules/subthemes/subthemes.cpp
@@ -78,9 +78,16 @@ void Subthemes::refreshCursorThemes()
     cursorThemes = getThemes(themeApi->listCursorTheme());
     for(auto &&info:cursorThemes) {
         KeyFile keyFile(',');
-        keyFile.loadFile(info->getPath()+"/cursor.theme");
-        info->setName(keyFile.getLocaleStr("Icon Theme","Name"));
-        info->setComment(keyFile.getLocaleStr("Icon Theme","Comment"));
+        const QString configFilePath = info->getPath()+"/cursor.theme";
+        if (QFile::exists(configFilePath)) {
+            keyFile.loadFile(configFilePath);
+            info->setName(keyFile.getLocaleStr("Icon Theme","Name"));
+            info->setComment(keyFile.getLocaleStr("Icon Theme","Comment"));
+        }
+
+        if (info->name().isEmpty()) {
+            info->setName(info->getId());
+        }
     }
 }
 


### PR DESCRIPTION
Ensure that name is a valid value

pms: BUG-286363
pms: BUG-286359

## Summary by Sourcery

Ensures that cursor theme names are valid by falling back to the theme ID if the name cannot be read from the configuration file.

Bug Fixes:
- Fixes an issue where cursor theme names could be invalid.
- Addresses a problem where the cursor theme name was not properly read.