### PR TITLE
chore(deb): unconflict with dde-kwin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.56) unstable; urgency=medium
+
+  * chore(deb): unconflict with dde-kwin
+
+ -- rewine <luhongxu@deepin.org>  Thu, 27 Mar 2025 17:52:40 +0800
+
 dde-appearance (1.1.55) unstable; urgency=medium
 
   * feat: replace using KX11Extras to get the current workspace

--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,5 @@ Depends:
    ${misc:Depends},
    ${shlibs:Depends},
    deepin-service-manager,
-Conflicts: dde-kwin
 Description: deepin desktop-environment - dde-appearance module
  dde appearance Provides application resource management and control services for the dde desktop environment.


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove conflict with dde-kwin.