### PR TITLE
fix: when QString is empty, call QString::front() will assert

### DIFF
--- a/src/service/modules/api/locale.cpp
+++ b/src/service/modules/api/locale.cpp
@@ -38,10 +38,8 @@ Locale::Locale()
 
             // 移除行首空行
             line.remove(QRegularExpression("^\\s+"));
-            if(line.front()=='#')
-            {
+            if(line.isEmpty() || line.front() == '#')
                 continue;
-            }
 
             line.remove(QRegularExpression("[\\t\\r\\n]+$"));
 


### PR DESCRIPTION
as title

pms: BUG-368711

## Summary by Sourcery

Bug Fixes:
- Add a check for empty QString before calling front() to avoid potential assertion failures