### PR TITLE
feat: replace using KX11Extras to get the current workspace

### DIFF
--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -12,9 +12,7 @@ set(PROJECT_NAME dde-appearance)
 find_package(PkgConfig REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Concurrent Gui)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Core Gui)
-find_package(KF6Config REQUIRED)
 find_package(KF6WindowSystem REQUIRED)
-find_package(KF6GlobalAccel REQUIRED)
 
 pkg_check_modules(Gio-2.0 REQUIRED IMPORTED_TARGET gio-2.0)
 pkg_check_modules(X11 REQUIRED IMPORTED_TARGET xcursor xfixes x11)
@@ -105,6 +103,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     PkgConfig::XCB
     PkgConfig::OPENSSL
     PkgConfig::FONTCONFIG
+    KF6::WindowSystem
 )
 include(GNUInstallDirs)
 install(TARGETS ${PLUGIN_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/deepin-service-manager/)

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -16,8 +16,8 @@
 #include "modules/subthemes/customtheme.h"
 #include "modules/dconfig/dconfigsettings.h"
 
-#include <dguiapplicationhelper.h>
 #include <xcb/xcb.h>
+#include <KX11Extras>
 
 #include <QColor>
 #include <QJsonArray>
@@ -36,7 +36,6 @@
 #define DEFAULT_WORKSPACE_COUNT (2) // 默认工作区数量
 
 DCORE_USE_NAMESPACE
-DGUI_USE_NAMESPACE
 
 AppearanceManager::AppearanceManager(AppearanceProperty *prop, QObject *parent)
     : QObject(parent)
@@ -1493,7 +1492,12 @@ bool AppearanceManager::doSetWallpaperSlideShow(const QString &monitorName, cons
 
 int AppearanceManager::getCurrentDesktopIndex()
 {
-    return m_dbusProxy->GetCurrentWorkspace();
+    if (utils::isTreeland()) {
+        // TODO: Need to implement
+        return 0;
+    } else {
+        return KX11Extras::currentDesktop();
+    }
 }
 
 void AppearanceManager::applyGlobalTheme(KeyFile &theme, const QString &themeName, const QString &defaultTheme, const QString &themePath)
@@ -1723,7 +1727,7 @@ void AppearanceManager::doSetCurrentWorkspaceBackgroundForMonitor(const QString 
     }
 
     // TODO delete, 临时适配Treeland
-    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+    if (utils::isTreeland()) {
         QString arg = QString("personalization/wallpaper?url=%1").arg(uri);
         DDBusSender()
                 .service("org.deepin.dde.ControlCenter1")
@@ -1759,7 +1763,7 @@ void AppearanceManager::doSetWorkspaceBackgroundForMonitor(const int &index, con
         m_wallpaperConfig = value.value();
     }
         // TODO delete, 临时适配Treeland
-    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+    if (utils::isTreeland()) {
         QString arg = QString("personalization/wallpaper?url=%1").arg(uri);
         DDBusSender()
                 .service("org.deepin.dde.ControlCenter1")

--- a/src/service/modules/api/utils.cpp
+++ b/src/service/modules/api/utils.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "utils.h"
-#include "../common/commondefine.h"
 
 #include <QFile>
 #include <QDir>
@@ -154,4 +153,10 @@ QString utils::GetUserCacheDir()
 QString utils::GetUserRuntimeDir()
 {
     return QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+}
+
+bool utils::isTreeland()
+{
+    static bool isTreeland = QString(qgetenv("XDG_SESSION_TYPE")).contains("wayland",  Qt::CaseInsensitive);
+    return isTreeland;
 }

--- a/src/service/modules/api/utils.h
+++ b/src/service/modules/api/utils.h
@@ -25,6 +25,7 @@ public:
     static QString GetUserCacheDir();
     static QString GetUserRuntimeDir();
     static void writeWallpaperConfig(const QVariant &wallpaper);
+    static bool isTreeland();
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
Prevent cyclic dbus calls with kwin

pms: TASK-368711

## Summary by Sourcery

Replace usage of DGuiApplicationHelper with a custom Treeland detection method and use KX11Extras for workspace detection

New Features:
- Add a new utility function `isTreeland()` to detect Treeland Wayland session

Bug Fixes:
- Prevent potential cyclic D-Bus calls when detecting workspace and platform

Enhancements:
- Refactor workspace and platform detection logic to use KX11Extras and a custom environment check

Chores:
- Remove dependencies on DGuiApplicationHelper and KF6Config