### PR TITLE
chore(debain): update version to 1.1.58

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.58) unstable; urgency=medium
+
+  * fix: rename deepin-kwin to kwin (need deepin-kwin >= 6.0.0)
+
+ -- rewine <luhongxu@deepin.org>  Wed, 09 Apr 2025 10:29:26 +0800
+
 dde-appearance (1.1.57) unstable; urgency=medium
 
   * remove startdde dependency


### PR DESCRIPTION
Log: rename deepin-kwin to kwin

## Summary by Sourcery

Chores:
- Bump package version number in the Debian changelog