### PR TITLE
fix: mark dde-fakewm requires plasma-kglobalaccel

### DIFF
--- a/misc/systemd/dde-fakewm.service.in
+++ b/misc/systemd/dde-fakewm.service.in
@@ -1,10 +1,12 @@
 [Unit]
 Description=dde window manager
 
-Requisite=plasma-kglobalaccel.service
+Requires=plasma-kglobalaccel.service
+After=plasma-kglobalaccel.service
 
 [Service]
-Type=simple
+Type=dbus
+BusName=com.deepin.wm
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" != "wayland" || exit 2'
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-fakewm
 Slice=session.slice


### PR DESCRIPTION
log: if the units listed in `Requisite` are not started already, they will not be started

close: https://github.com/linuxdeepin/deepin-kwin/pull/339

## Summary by Sourcery

Bug Fixes:
- Ensure that plasma-kglobalaccel is started before dde-fakewm by using Requisite directive in the systemd service file