### PR TITLE
feat: Starting no longer initializes' Wallpaper-Uris' and 'Wallpaper_Slideshow'

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -96,10 +96,6 @@ bool AppearanceManager::init()
 
     new ThemeFontSyncConfig("org.deepin.dde.Appearance1", "/org/deepin/dde/Appearance1/sync", QSharedPointer<AppearanceManager>(this));
     new BackgroundSyncConfig("org.deepin.dde.Appearance1", "/org/deepin/dde/Appearance1/Background", QSharedPointer<AppearanceManager>(this));
-
-    if (m_property->wallpaperURls->isEmpty()) {
-        updateNewVersionData();
-    }
     m_zone = m_dbusProxy->timezone();
 
     connect(m_dbusProxy.get(), &AppearanceDBusProxy::TimezoneChanged, this, &AppearanceManager::handleTimezoneChanged);


### PR DESCRIPTION
- When starting, the global theme will be set, and at the same time as setting the wallpaper, the message 'Wallpaper-Uris' will appear 
-The configuration of "Wallpaper_Slideshow" will be managed in the org.deepin.dde.wallpaperslideshow service

pms: BUG-304817