### PR TITLE
chore: bump version to 1.1.61

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-appearance (1.1.61) unstable; urgency=medium
+
+  * feat: Starting no longer initializes' Wallpaper-Uris' and
+    'Wallpaper_Slideshow'
+  * feat: Decoupling themes and wallpapers
+  * fix: 解决缩放设置失效的问题
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Tue, 29 Apr 2025 14:23:02 +0800
+
 dde-appearance (1.1.60) unstable; urgency=medium
 
   * fix: mark dde-fakewm requires plasma-kglobalaccel


### PR DESCRIPTION
update changelog to 1.1.61

## Summary by Sourcery

Chores:
- Update `debian/changelog`.