### PR TITLE
chore: bump version to 1.1.63

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.63) unstable; urgency=medium
+
+  * fix: correct SLOT syntax to avoid QObject::connect warning
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 19 Jun 2025 10:29:09 +0800
+
 dde-appearance (1.1.62) unstable; urgency=medium
 
   * refactor: improve memory management and code quality


### PR DESCRIPTION
update changelog to 1.1.63

## Summary by Sourcery

Chores:
- Update debian/changelog entry to version 1.1.63