### PR TITLE
chore: bump version to 1.1.64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.64) unstable; urgency=medium
+
+  * Release 1.1.64
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 19 Jun 2025 13:52:11 +0800
+
 dde-appearance (1.1.63) unstable; urgency=medium
 
   * fix: correct SLOT syntax to avoid QObject::connect warning


### PR DESCRIPTION
update changelog to 1.1.64

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 1.1.64