### PR TITLE
chore: bump version to 1.1.65

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.65) unstable; urgency=medium
+
+  * chore: remove es_MX translation
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Mon, 23 Jun 2025 17:17:04 +0800
+
 dde-appearance (1.1.64) unstable; urgency=medium
 
   * refactor: improve wallpaper handling logic


### PR DESCRIPTION
update changelog to 1.1.65

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 1.1.65