### PR TITLE
fix: add hardening flags and compiler warnings

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,10 @@ export QT_SELECT=5
 
 include /usr/share/dpkg/default.mk
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 %:
 	dh $@ --buildsystem=cmake


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for security
2. Included -Wall flag for C/C++ compilers to enable all warnings
3. Added linker flags for security hardening (RELRO, NX, immediate binding)
4. These changes improve security and catch potential issues during build

fix: 添加安全加固标志和编译器警告

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以提高安全性
2. 包含 -Wall 标志用于 C/C++ 编译器以启用所有警告
3. 添加链接器标志用于安全加固 (RELRO, NX, 立即绑定)
4. 这些更改提高了安全性并在构建时捕获潜在问题

## Summary by Sourcery

Enable comprehensive security hardening and compiler warnings in the build process

Build:
- Add DEB_BUILD_MAINT_OPTIONS with hardening=+all
- Enable -Wall flag for C/C++ compilers to catch warnings
- Add security-oriented linker flags (RELRO, NX, immediate binding)