### PR TITLE
refactor: remove QT theme setting functionality

### DIFF
--- a/src/service/modules/api/themes.cpp
+++ b/src/service/modules/api/themes.cpp
@@ -210,11 +210,6 @@ bool ThemesApi::setGtkTheme(QString name)
     }
 
     xSetting->setValue(DCKEYTHEME, name);
-    if (!setQTTheme()) {
-        xSetting->setValue(DCKEYTHEME, old);
-        qWarning() << "setQTTheme failed";
-        return false;
-    }
 
     return true;
 }
@@ -430,41 +425,6 @@ void ThemesApi::doSetGtk3Prop(QString key, QString value, QString file, KeyFile 
 {
     keyfile.setKey(GTK3GROUPSETTINGS, key, value);
     keyfile.saveToFile(file);
-}
-
-bool ThemesApi::setQTTheme()
-{
-    QString config = utils::GetUserConfigDir();
-    config += "/Trolltech.conf";
-    return setQt4Theme(config);
-}
-
-bool ThemesApi::setQt4Theme(QString config)
-{
-    if (!utils::isFileExists(config)) {
-        return false;
-    }
-
-    KeyFile keyfile;
-    keyfile.loadFile(config);
-
-    QString value = keyfile.getStr("Qt", "style");
-    if (value == "GTK+")
-        return true;
-
-    if (config.length() == 0)
-        return false;
-
-    QFile file(config);
-    if (file.exists()) {
-        QDir dir(config.left(config.lastIndexOf("/")));
-        if (!dir.mkpath(config.left(config.lastIndexOf("/"))))
-            return false;
-    }
-
-    keyfile.setKey("Qt", "style", "GTK+");
-
-    return keyfile.saveToFile(config);
 }
 
 bool ThemesApi::setDefaultCursor(QString name)

--- a/src/service/modules/api/themes.h
+++ b/src/service/modules/api/themes.h
@@ -53,8 +53,6 @@ public:
     void setGtk3Prop(QString key, QString value, QString file);
     bool isGtk3PropEqual(QString key, QString value,KeyFile& keyfile);
     void doSetGtk3Prop(QString key,QString value, QString file, KeyFile& keyfile);
-    bool setQTTheme();
-    bool setQt4Theme(QString config);
     bool setDefaultCursor(QString name);
     void setGtkCursor(QString name);
     void setQtCursor(QString name);


### PR DESCRIPTION
1. Removed setQTTheme() and setQt4Theme() functions from ThemesApi class
2. Removed QT theme setting check from setGtkTheme() method
3. These changes were made because QT theme management is no longer needed in the application
4. The GTK theme setting now operates independently without QT theme validation

refactor: 移除QT主题设置功能

1. 从ThemesApi类中移除了setQTTheme()和setQt4Theme()函数
2. 从setGtkTheme()方法中移除了QT主题设置检查
3. 这些修改是因为应用程序中不再需要QT主题管理功能
4. GTK主题设置现在可以独立运行，不再需要QT主题验证
5. Qt主题通过dtk和风格插件来控制，Qt4已经基本没有应用使用，故移除

## Summary by Sourcery

Remove obsolete QT theme management functionality and decouple GTK theme setting from QT validation

Enhancements:
- Remove setQTTheme() and setQt4Theme() methods from ThemesApi
- Remove QT theme validation check from setGtkTheme() so GTK theme operates independently