### PR TITLE
chore: bump version to 1.1.68

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.68) unstable; urgency=medium
+
+  * feat: add custom lock screen wallpaper flag
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 01 Aug 2025 10:45:58 +0800
+
 dde-appearance (1.1.67) unstable; urgency=medium
 
   * refactor: remove QT theme setting functionality


### PR DESCRIPTION
update changelog to 1.1.68

## Summary by Sourcery

Build:
- Update Debian changelog to version 1.1.68