### PR TITLE
chore: bump version to 1.1.69

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.69) unstable; urgency=medium
+
+  * Release 1.1.69
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 05 Aug 2025 20:27:33 +0800
+
 dde-appearance (1.1.68) unstable; urgency=medium
 
   * feat: add custom lock screen wallpaper flag


### PR DESCRIPTION
update changelog to 1.1.69

## Summary by Sourcery

Chores:
- Update Debian changelog to version 1.1.69