### PR TITLE
chore: bump version to 1.1.69

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.69) unstable; urgency=medium
+
+  * refactor: update key names to camelCase in accelerator map
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 28 Aug 2025 14:36:24 +0200
+
 dde-appearance (1.1.68) unstable; urgency=medium
 
   * feat: add custom lock screen wallpaper flag


### PR DESCRIPTION
update changelog to 1.1.69

## Summary by Sourcery

Chores:
- Update Debian changelog to version 1.1.69