### PR TITLE
chore: bump version to 1.1.70

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.70) unstable; urgency=medium
+
+  * docs: add GPLv3 license and update license references
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:03:39 +0800
+
 dde-appearance (1.1.69) unstable; urgency=medium
 
   * refactor: update key names to camelCase in accelerator map


### PR DESCRIPTION
update changelog to 1.1.70

## Summary by Sourcery

Bump package version to 1.1.70 and update Debian changelog accordingly

Build:
- Bump version to 1.1.70 in Debian packaging

Documentation:
- Update Debian changelog for the 1.1.70 release