### PR TITLE
fix: display banner notification after changing scale

### DIFF
--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,6 +32,7 @@ AppearanceDBusProxy::AppearanceDBusProxy(QObject *parent)
     QDBusConnection::sessionBus().connect("org.deepin.dde.XSettings1","/org/deepin/dde/XSettings1","org.deepin.dde.XSettings1","SetScaleFactorDone",this,SIGNAL(SetScaleFactorDone()));
 
     QDBusConnection::sessionBus().connect("org.deepin.dde.Display1", "/org/deepin/dde/Display1", "org.freedesktop.DBus.Properties","PropertiesChanged", this, SLOT(onDisplayPropertiesChanged(QDBusMessage)));
+    QDBusConnection::sessionBus().connect("org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications", "NotificationClosed", this, SLOT(onNotificationClosed(uint, uint)));
 }
 
 void AppearanceDBusProxy::setUserInterface(const QString &userPath)
@@ -293,4 +294,12 @@ void AppearanceDBusProxy::onDisplayPropertiesChanged(const QDBusMessage &message
             }
         }
     }
+}
+
+void AppearanceDBusProxy::onNotificationClosed(uint id, uint reason)
+{
+    Q_UNUSED(reason)
+    // reset m_nid after notification closure
+    if (id == m_nid)
+        m_nid = 0;
 }

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -130,6 +130,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void onDisplayPropertiesChanged(const QDBusMessage &message);
+    void onNotificationClosed(uint, uint);
 
 private:
     DDBusInterface *m_wmInterface;


### PR DESCRIPTION
After clicking the 'Later' button to turn off the scale notification, reset the replaceId of the notification so that the scale notification can be triggered when the scale is changed again

点击“稍后注销”按钮关闭缩放通知后，重置对应通知的replaceId，使得再次更改缩放后可以触发通知

Log: 点击“稍后注销”按钮关闭缩放通知后，重置对应通知的replaceId
PMS: BUG-358697
Influence: 缩放通知关闭后，再次更改缩放后可以触发通知

## Summary by Sourcery

Bug Fixes:
- Fix scale change banner not reappearing after the user dismisses it once by resetting the stored notification ID when the notification is closed.