### PR TITLE
chore: update changelog to 1.1.81

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-appearance (1.1.81) unstable; urgency=medium
+
+  * Release 1.1.81
+
+ -- zhangkun <zhangkun2@uniontech.com>  Mon, 25 May 2026 11:10:13 +0800
+
 dde-appearance (1.1.80) unstable; urgency=medium
 
   * fix: display banner notification after changing scale


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.1.81

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.1.81
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 1.1.81 in debian/changelog.