### PR TITLE
[暂不合并]feat(fake-wm): add dde-thp-disable pre-start script to service

### DIFF
--- a/misc/systemd/dde-fakewm.service.in
+++ b/misc/systemd/dde-fakewm.service.in
@@ -8,5 +8,6 @@ After=plasma-kglobalaccel.service
 Type=dbus
 BusName=com.deepin.wm
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" != "wayland" || exit 2'
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-fakewm
 Slice=session.slice


### PR DESCRIPTION
1. Added ExecStartPre hook to run dde-thp-disable before dde-fakewm starts
2. The pre-start script ignores failure to avoid blocking service startup

Log: add dde-thp-disable pre-start script to dde-fakewm service

feat(fake-wm): 在服务中新增 dde-thp-disable 预启动脚本

1. 添加了 ExecStartPre 钩子，在 dde-fakewm 启动前运行 dde-thp-disable
2. 预启动脚本忽略执行失败，避免阻塞服务启动

Log: 在 dde-fakewm 服务中新增 dde-thp-disable 预启动脚本
PMS: TASK-390043

## Summary by Sourcery

Enhancements:
- Run dde-thp-disable as an ExecStartPre step for the dde-fakewm systemd service to disable transparent huge pages before the window manager starts.