### PR TITLE
fix(theme): skip initGlobalTheme for treeland environment

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1695,6 +1695,13 @@ void AppearanceManager::initDtkSizeMode(){
 
 void AppearanceManager::initGlobalTheme()
 {
+    // treeland 不需要走初始化全局主题逻辑，treeland下所有的个性化设置全部走控制中心的协议
+    if (utils::isTreeland()) {
+        qInfo() << "treeland, skip initGlobalTheme";
+        m_currentGlobalTheme = m_property->globalTheme;
+        return;
+    }
+
     QVector<QSharedPointer<Theme>> globalList = m_subthemes->listGlobalThemes();
     bool bFound = false;
 


### PR DESCRIPTION
Treeland does not need global theme initialization logic. All personalization settings in treeland follow the control center protocol instead.

treeland环境下跳过全局主题初始化，treeland下所有个性化设置走控制中心协议。

Log: treeland下跳过全局主题初始化
PMS: TASK-391987
Influence: treeland环境下不再执行全局主题初始化，避免与控制中心协议冲突。
Change-Id: I70dcfee6981869a740bd444799f273efa34d41bc

## Summary by Sourcery

Skip global theme initialization in treeland environments to align personalization handling with the control center protocol.

Bug Fixes:
- Prevent global theme initialization from running in treeland, avoiding conflicts with control center-based personalization settings.

Enhancements:
- Log when global theme initialization is skipped in treeland and ensure the current global theme is taken from existing properties.

Documentation:
- Update copyright header years in appearance manager implementation source file.