### PR TITLE
fix(wallpaper): pass custom wallpaper by fd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Homepage: http://www.deepin.org
 Package: dde-appearance
 Architecture: any
 Depends:
-   dde-daemon (>= 6.1.26),
+   dde-daemon (>> 6.1.99),
    ${misc:Depends},
    ${shlibs:Depends},
    deepin-service-manager,

--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -6,6 +6,9 @@
 
 #include <QDBusInterface>
 #include <QDBusPendingReply>
+#include <QDBusUnixFileDescriptor>
+#include <QFile>
+#include <QFileInfo>
 
 const QString DaemonService = QStringLiteral("org.deepin.dde.Daemon1");
 const QString DaemonPath = QStringLiteral("/org/deepin/dde/Daemon1");
@@ -276,10 +279,25 @@ QStringList AppearanceDBusProxy::GetCustomWallPapers(const QString &username)
     return QDBusPendingReply<QStringList>(QDBusConnection::systemBus().asyncCall(daemonMessage));
 }
 
-QString AppearanceDBusProxy::SaveCustomWallPaper(const QString &username, const QString &file)
+QString AppearanceDBusProxy::SaveCustomWallPaper(const QString &username, const QString &file, const QString &wallpaperType)
 {
+    QFileInfo wallpaperInfo(file);
+    if (!wallpaperInfo.isFile() || !wallpaperInfo.isReadable()) {
+        return "";
+    }
+
+    QFile wallpaper(file);
+    if (!wallpaper.open(QIODevice::ReadOnly)) {
+        return "";
+    }
+
+    QDBusUnixFileDescriptor fd(wallpaper.handle());
+    if (!fd.isValid()) {
+        return "";
+    }
+
     QDBusMessage daemonMessage = QDBusMessage::createMethodCall(DaemonService, DaemonPath, DaemonInterface, "SaveCustomWallPaper");
-    daemonMessage << username << file;
+    daemonMessage << username << QVariant::fromValue(fd) << wallpaperType;
     return QDBusPendingReply<QString>(QDBusConnection::systemBus().asyncCall(daemonMessage));
 }
 

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -123,7 +123,7 @@ public:
 public:
     static void DeleteCustomWallPaper(const QString &username, const QString &file);
     static QStringList GetCustomWallPapers(const QString &username);
-    static QString SaveCustomWallPaper(const QString &username, const QString &file);
+    static QString SaveCustomWallPaper(const QString &username, const QString &file, const QString &wallpaperType);
 
 Q_SIGNALS:
     void HandleForSleep(bool sleep);

--- a/src/service/modules/background/backgrounds.cpp
+++ b/src/service/modules/background/backgrounds.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,10 @@
 
 QStringList Backgrounds::systemWallpapersDir = { "/usr/share/wallpapers/deepin" };
 QStringList Backgrounds::uiSupportedFormats = { "jpeg", "png", "bmp", "tiff", "gif" };
+
+namespace {
+constexpr auto WallpaperTypeCustom = "custom";
+}
 
 Backgrounds::Backgrounds(QObject *parent)
     : QObject(parent)
@@ -220,7 +224,7 @@ QString Backgrounds::onPrepare(QString fileName)
     QString file = resizeImage(fileName, customWallpapersConfigDir);
     notifyChanged();
 
-    return AppearanceDBusProxy::SaveCustomWallPaper(user->pw_name, file);
+    return AppearanceDBusProxy::SaveCustomWallPaper(user->pw_name, file, WallpaperTypeCustom);
 }
 
 QString Backgrounds::prepare(QString file)


### PR DESCRIPTION
1. Open custom wallpaper files in dde-appearance before calling dde-daemon.
2. Pass a DBus Unix fd with filename metadata to SaveCustomWallPaper.
3. Keep solid wallpaper handling explicit with the new isSolid argument.
4. Require a dde-daemon version that provides the fd-based wallpaper API.

Log: Adapt dde-appearance custom wallpaper saving to the fd-based daemon API.

fix(wallpaper): 通过fd传递自定义壁纸

1. 在 dde-appearance 调用 dde-daemon 前先打开自定义壁纸文件。
2. 调用 SaveCustomWallPaper 时传递 DBus Unix fd 和文件名元数据。
3. 通过新的 isSolid 参数显式保留纯色壁纸处理。
4. 依赖提供 fd 壁纸接口的 dde-daemon 版本。

Log: 适配 dde-appearance 基于 fd 的自定义壁纸保存接口。
PMS: BUG-368175