### PR TITLE
feat: skip set globaltheme on treeland

### DIFF
--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -1527,6 +1527,11 @@ int AppearanceManager::getCurrentDesktopIndex()
 void AppearanceManager::applyGlobalTheme(KeyFile &theme, const QString &themeName, const QString &defaultTheme, const QString &themePath, const QString &themeId)
 {
     m_globalThemeUpdating = true;
+    // treeland 仅记录globalTheme的设置状态，不做实际的主题设置，实际的主题设置在dcc中完成
+    if (utils::isTreeland()) {
+        m_globalThemeUpdating = false;
+        return;
+    }
     QString defTheme = (defaultTheme.isEmpty() || defaultTheme == themeName) ? QString() : defaultTheme;
     auto getValue = [&theme, &themeId, this](const QString &section, const QString &key) -> QString{
         QString ret = theme.getStr(section, key);


### PR DESCRIPTION
treeland 下仅记录globaltheme的状态，不做设置

pms: BUG-366837

## Summary by Sourcery

New Features:
- Add Treeland-specific handling to bypass actual global theme application while recording its configuration state.