### PR TITLE
fix: include concat-screen wallpapers in property update for DDE-CONCAT-SCREEN

### DIFF
--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -159,6 +159,17 @@ QStringList AppearanceDBusProxy::ListOutputNames()
 {
     return QDBusPendingReply<QStringList>(m_displayInterface->asyncCall(QStringLiteral("ListOutputNames")));
 }
+
+bool AppearanceDBusProxy::isConcatScreenEnabled()
+{
+    return qvariant_cast<bool>(m_displayInterface->property("ConcatScreenEnabled"));
+}
+
+QString AppearanceDBusProxy::concatScreenName()
+{
+    return qvariant_cast<QString>(m_displayInterface->property("ConcatScreenName"));
+}
+
 // xSettingsInterface
 void AppearanceDBusProxy::SetString(const QString &prop, const QString &v)
 {

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -55,6 +55,8 @@ public:
     QString primary();
     Q_PROPERTY(QList<QDBusObjectPath> Monitors READ monitors NOTIFY MonitorsChanged)
     QList<QDBusObjectPath> monitors();
+    bool isConcatScreenEnabled();
+    QString concatScreenName();
 
 public Q_SLOTS:
     QStringList ListOutputNames();

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -763,13 +763,14 @@ void AppearanceManager::doUpdateWallpaperURIs()
 
     QStringList monitorList = m_dbusProxy->ListOutputNames();
 
+    QString key;
+    const auto workspaceCount = getWorkspaceCount();
     for (int i = 0; i < monitorList.length(); i++) {
-        for (int idx = 1; idx <= getWorkspaceCount(); idx++) {
-            QString wallpaperUri = getWallpaperUri(QString::number(idx), monitorList.at(i));
+        for (int idx = 1; idx <= workspaceCount; idx++) {
+            const QString wallpaperUri = getWallpaperUri(QString::number(idx), monitorList.at(i));
             if (wallpaperUri.isEmpty())
                 continue;
 
-            QString key;
             if (m_monitorMap.count(monitorList[i]) != 0) {
                 key = QString::asprintf("%s&&%d", m_monitorMap[monitorList[i]].toLatin1().data(), idx);
             } else {
@@ -777,6 +778,23 @@ void AppearanceManager::doUpdateWallpaperURIs()
             }
 
             monitorWallpaperUris[key] = wallpaperUri;
+        }
+    }
+
+    // 跨屏拼接模式：DDE-CONCAT-SCREEN 是一个虚拟 RANDR Monitor，不在 ListOutputNames()
+    // 返回的物理显示器列表中。当拼接模式激活时，需将其壁纸也纳入 WallpaperURls，
+    // 确保 WM 合成器等订阅方能通过 PropertiesChanged 信号感知拼接屏的壁纸变更。
+    if (m_dbusProxy->isConcatScreenEnabled()) {
+        const QString concatScreenName = m_dbusProxy->concatScreenName();
+        if (!concatScreenName.isEmpty()) {
+            for (int idx = 1; idx <= workspaceCount; idx++) {
+                const QString wallpaperUri = getWallpaperUri(QString::number(idx), concatScreenName);
+                if (wallpaperUri.isEmpty())
+                    continue;
+
+                key = QString("%1&&%2").arg(concatScreenName).arg(idx);
+                monitorWallpaperUris[key] = wallpaperUri;
+            }
         }
     }
 


### PR DESCRIPTION
When `isConcatScreenEnabled` is active, the virtual monitor "DDE- CONCAT-SCREEN" is not part of the physical display list returned by `ListOutputNames()`. Previously, its wallpapers would be missing from the `WallpaperURIs` property update, causing WM/compositor subscribers to be unaware of wallpaper changes on the concatenated screen. This patch iterates over the concat-screen’s workspace wallpapers and inserts them into `monitorWallpaperUris`, ensuring complete property synchronization.

Log: Fixed missing concat-screen wallpapers in WallpaperURIs property update

Influence:
1. Enable multi‑display with screen concatenation and set wallpapers for the concat screen.
2. Verify that the wallpaper URIs property (e.g., via DBus `PropertiesChanged`) includes all entries for the concatenated virtual screen.
3. Check that each workspace wallpaper for the concat screen is correctly reported.
4. Regression: Ensure physical monitor wallpapers remain unchanged and fully listed.

perf: 在属性更新中纳入拼接屏壁纸

当 `isConcatScreenEnabled` 激活时，虚拟显示器 "DDE-CONCAT-SCREEN" 不在 物理显示器列表中，原有逻辑未将其壁纸加入 `WallpaperURIs` 属性更新，导致
WM/合成器无法感知拼接屏的壁纸变更。本补丁遍历拼接屏每个工作区的壁纸并写
入属性映射，确保属性同步完整。

Log: 修复拼接屏壁纸未包含在 WallpaperURIs 属性更新中的问题

Influence:
1. 启用多屏拼接模式，为拼接屏设置壁纸
2. 验证属性更新中（如通过 DBus `PropertiesChanged`）包含拼接虚拟屏的完整 壁纸项
3. 确认拼接屏各工作区壁纸均正确上报
4. 回归测试物理显示器壁纸不受影响且完整列出

PMS: BUG-362687