### PR TITLE
refactor(appearance): migrate xsettings from dbus to dconfig

### DIFF
--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "appearancedbusproxy.h"
+#include "modules/api/utils.h"
 
 #include <QDBusInterface>
 #include <QDBusPendingReply>
@@ -17,7 +18,6 @@ const QString DaemonInterface = QStringLiteral("org.deepin.dde.Daemon1");
 AppearanceDBusProxy::AppearanceDBusProxy(QObject *parent)
     : QObject(parent)
     , m_displayInterface(new QDBusInterface("org.deepin.dde.Display1", "/org/deepin/dde/Display1", "org.deepin.dde.Display1", QDBusConnection::sessionBus(), this))
-    , m_xSettingsInterface(new QDBusInterface("org.deepin.dde.XSettings1", "/org/deepin/dde/XSettings1", "org.deepin.dde.XSettings1", QDBusConnection::sessionBus(),this))
     , m_timeDateInterface(new DDBusInterface("org.freedesktop.timedate1", "/org/freedesktop/timedate1", "org.freedesktop.timedate1", QDBusConnection::systemBus(), this))
     , m_nid(0)
 {
@@ -170,32 +170,6 @@ QString AppearanceDBusProxy::concatScreenName()
     return qvariant_cast<QString>(m_displayInterface->property("ConcatScreenName"));
 }
 
-// xSettingsInterface
-void AppearanceDBusProxy::SetString(const QString &prop, const QString &v)
-{
-    m_xSettingsInterface->asyncCall(QStringLiteral("SetString"), prop, v);
-}
-void AppearanceDBusProxy::SetInteger(const QString &prop, const int &v)
-{
-    m_xSettingsInterface->asyncCall(QStringLiteral("SetInteger"), prop, v);
-}
-double AppearanceDBusProxy::GetScaleFactor()
-{
-    return QDBusPendingReply<double>(m_xSettingsInterface->asyncCall(QStringLiteral("GetScaleFactor")));
-}
-void AppearanceDBusProxy::SetScaleFactor(double scale)
-{
-    m_xSettingsInterface->asyncCall(QStringLiteral("SetScaleFactor"), scale);
-}
-ScaleFactors AppearanceDBusProxy::GetScreenScaleFactors()
-{
-    return QDBusPendingReply<ScaleFactors>(m_xSettingsInterface->asyncCall(QStringLiteral("GetScreenScaleFactors")));
-}
-void AppearanceDBusProxy::SetScreenScaleFactors(const ScaleFactors &factors)
-{
-    m_xSettingsInterface->asyncCall(QStringLiteral("SetScreenScaleFactors"), QVariant::fromValue(factors));
-}
-
 QString AppearanceDBusProxy::FindUserById(const QString &uid)
 {
     QDBusMessage accountsMessage = QDBusMessage::createMethodCall("org.deepin.dde.Accounts1", "/org/deepin/dde/Accounts1", "org.deepin.dde.Accounts1", "FindUserById");
@@ -331,4 +305,24 @@ void AppearanceDBusProxy::onNotificationClosed(uint id, uint reason)
     // reset m_nid after notification closure
     if (id == m_nid)
         m_nid = 0;
+}
+
+void AppearanceDBusProxy::SetScaleFactor(double scale)
+{
+    if (utils::isTreeland()) {
+        qWarning() << "treeland env, skip set scale to xsettings";
+        return;
+    }
+    QDBusInterface iface("org.deepin.dde.XSettings1", "/org/deepin/dde/XSettings1", "org.deepin.dde.XSettings1", QDBusConnection::sessionBus());
+    iface.asyncCall(QStringLiteral("SetScaleFactor"), scale);
+}
+
+void AppearanceDBusProxy::SetScreenScaleFactors(const ScaleFactors &factors)
+{
+    if (utils::isTreeland()) {
+        qWarning() << "treeland env, skip get scale from xsettings";
+        return;
+    }
+    QDBusInterface iface("org.deepin.dde.XSettings1", "/org/deepin/dde/XSettings1", "org.deepin.dde.XSettings1", QDBusConnection::sessionBus());
+    iface.asyncCall(QStringLiteral("SetScreenScaleFactors"), QVariant::fromValue(factors));
 }

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -67,11 +67,7 @@ Q_SIGNALS:
 
     // xSettingsInterface
 public Q_SLOTS:
-    void SetString(const QString &prop, const QString &v);
-    void SetInteger(const QString &prop, const int &v);
-    double GetScaleFactor();
     void SetScaleFactor(double scale);
-    ScaleFactors GetScreenScaleFactors();
     void SetScreenScaleFactors(const ScaleFactors &factors);
 
 Q_SIGNALS:
@@ -137,7 +133,6 @@ private Q_SLOTS:
 private:
     DDBusInterface *m_wmInterface;
     QDBusInterface *m_displayInterface;
-    QDBusInterface *m_xSettingsInterface;
     DDBusInterface *m_timeDateInterface;
     QSharedPointer<DDBusInterface> m_userInterface;
     uint m_nid;

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -967,7 +967,7 @@ bool AppearanceManager::doUpdateFonts(double size)
         qWarning() << "set font size error:can not set family ";
         return false;
     }
-    m_dbusProxy->SetString("Qt/FontPointSize", QString::number(size));
+    m_XSettingsDconfig->setValue("qt-font-point-size", QString::number(size));
     if (!setDQtTheme({ QTKEYFONTSIZE }, { QString::number(size) })) {
         qWarning() << "set font size error:can not set qt theme ";
         return false;
@@ -1130,7 +1130,7 @@ bool AppearanceManager::doSetStandardFont(QString value)
         qWarning() << "set standard font error:can not set family ";
         return false;
     }
-    m_dbusProxy->SetString("Qt/FontName", value);
+    m_XSettingsDconfig->setValue("qt-font-name", value);
     if (!setDQtTheme({ QTKEYFONT }, { value })) {
         qWarning() << "set standard font error:can not set qt theme ";
         return false;
@@ -1155,7 +1155,7 @@ bool AppearanceManager::doSetMonospaceFont(QString value)
         return false;
     }
 
-    m_dbusProxy->SetString("Qt/MonoFontName", value);
+    m_XSettingsDconfig->setValue("qt-mono-font-name", value);
     if (!setDQtTheme({ QTKEYMONOFONT }, { value })) {
         qWarning() << "set monospace font error:can not set qt theme ";
         return false;
@@ -1220,12 +1220,7 @@ QString AppearanceManager::doGetWallpaperSlideShow(QString monitorName)
 
 double AppearanceManager::getScaleFactor()
 {
-    double scaleFactor = 0.0;
-    if (m_XSettingsDconfig) {
-        scaleFactor = m_XSettingsDconfig->value("scale-factor").toDouble();
-    } else {
-        scaleFactor = m_dbusProxy->GetScaleFactor();
-    }
+    double scaleFactor = m_XSettingsDconfig->value("scale-factor").toDouble();
     qInfo() << __FUNCTION__ << "UpdateScaleFactor" << scaleFactor;
     if (scaleFactor <= 0) {
         scaleFactor = 1.0;
@@ -1236,7 +1231,20 @@ double AppearanceManager::getScaleFactor()
 
 ScaleFactors AppearanceManager::getScreenScaleFactors()
 {
-    return m_dbusProxy->GetScreenScaleFactors();
+    ScaleFactors factors;
+    QString raw = m_XSettingsDconfig->value("individual-scaling").toString();
+    const QStringList pairs = raw.split(u';', Qt::SkipEmptyParts);
+    for (const QString &pair : pairs) {
+        int eq = pair.indexOf(u'=');
+        if (eq > 0) {
+            bool ok = false;
+            double val = pair.mid(eq + 1).toDouble(&ok);
+            if (ok) {
+                factors.insert(pair.left(eq), val);
+            }
+        }
+    }
+    return factors;
 }
 
 bool AppearanceManager::setScaleFactor(double scale)
@@ -1713,7 +1721,7 @@ QString AppearanceManager::getWallpaperUri(const QString &index, const QString &
 }
 
 void AppearanceManager::initDtkSizeMode(){
-    m_dbusProxy->SetInteger("DTK/SizeMode",m_property->dtkSizeMode);
+    m_XSettingsDconfig->setValue("dtk-size-mode", static_cast<int>(m_property->dtkSizeMode));
 }
 
 void AppearanceManager::initGlobalTheme()
@@ -1852,7 +1860,7 @@ QString AppearanceManager::doGetWorkspaceBackgroundForMonitor(const int &index, 
 void AppearanceManager::doSetDTKSizeMode(int value) {
     if (value != m_property->dtkSizeMode) {
         setDTKSizeMode(value);
-        m_dbusProxy->SetInteger("DTK/SizeMode",value);
+        m_XSettingsDconfig->setValue("dtk-size-mode", value);
     }
 }
 
@@ -1860,7 +1868,7 @@ void AppearanceManager::doSetQtScrollBarPolicy(int value)
 {
     if (value != m_property->qtScrollBarPolicy) {
         setQtScrollBarPolicy(value);
-        m_dbusProxy->SetInteger("Qt/ScrollBarPolicy",value);
+        m_XSettingsDconfig->setValue("qt-scrollbar-policy", value);
     }
 }
 


### PR DESCRIPTION
1. Removed xSettingsInterface DBus proxy and its SetString/SetInteger methods
2. Added SetScaleFactor with treeland environment check
3. Migrated font/scrollbar/DTK-size settings to XSettingsDconfig
4. Changed scale factor reading from dbus to XSettingsDconfig parsing
5. Cleaned up unused GetScaleFactor and GetScreenScaleFactors methods

Log: Migrate xSettings-related settings from direct DBus calls to XSettingsDconfig

refactor(appearance): 将 xsettings 从 dbus 迁移到 dconfig

1. 移除 xSettingsInterface DBus 代理及其 SetString/SetInteger 方法
2. 添加 SetScaleFactor 并增加 treeland 环境判断
3. 将字体/滚动条策略/DTK 大小模式等设置迁移到 XSettingsDconfig
4. 缩放因子读取从 dbus 改为从 XSettingsDconfig 解析
5. 清理未使用的 GetScaleFactor 和 GetScreenScaleFactors 方法

Log: 将 xSettings 相关设置从直接 DBus 调用迁移到 XSettingsDconfig