### PR TITLE
fix: refresh wallpaper table on concat toggle to fix blank preview

### DIFF
--- a/src/service/dbus/appearancedbusproxy.cpp
+++ b/src/service/dbus/appearancedbusproxy.cpp
@@ -155,6 +155,11 @@ QList<QDBusObjectPath> AppearanceDBusProxy::monitors()
     return qvariant_cast<QList<QDBusObjectPath>>(m_displayInterface->property("Monitors"));
 }
 
+QStringList AppearanceDBusProxy::ListEffectiveOutputNames()
+{
+    return QDBusPendingReply<QStringList>(m_displayInterface->asyncCall(QStringLiteral("ListEffectiveOutputNames")));
+}
+
 QStringList AppearanceDBusProxy::ListOutputNames()
 {
     return QDBusPendingReply<QStringList>(m_displayInterface->asyncCall(QStringLiteral("ListOutputNames")));
@@ -163,11 +168,6 @@ QStringList AppearanceDBusProxy::ListOutputNames()
 bool AppearanceDBusProxy::isConcatScreenEnabled()
 {
     return qvariant_cast<bool>(m_displayInterface->property("ConcatScreenEnabled"));
-}
-
-QString AppearanceDBusProxy::concatScreenName()
-{
-    return qvariant_cast<QString>(m_displayInterface->property("ConcatScreenName"));
 }
 
 QString AppearanceDBusProxy::FindUserById(const QString &uid)
@@ -292,7 +292,7 @@ void AppearanceDBusProxy::onDisplayPropertiesChanged(const QDBusMessage &message
         QVariantMap changedProps = qdbus_cast<QVariantMap>(message.arguments().at(1).value<QDBusArgument>());
         for (QVariantMap::const_iterator it = changedProps.cbegin(); it != changedProps.cend(); ++it) {
             auto prop = it.key().toLatin1() + "Changed";
-            if (prop == "PrimaryChanged" || prop == "MonitorsChanged") {
+            if (prop == "PrimaryChanged" || prop == "MonitorsChanged" || prop == "ConcatScreenEnabledChanged") {
                 QMetaObject::invokeMethod(this, prop, Qt::DirectConnection, QGenericArgument(it.value().typeName(), it.value().data()));
             }
         }

--- a/src/service/dbus/appearancedbusproxy.h
+++ b/src/service/dbus/appearancedbusproxy.h
@@ -55,8 +55,9 @@ public:
     QString primary();
     Q_PROPERTY(QList<QDBusObjectPath> Monitors READ monitors NOTIFY MonitorsChanged)
     QList<QDBusObjectPath> monitors();
+    Q_PROPERTY(bool ConcatScreenEnabled READ isConcatScreenEnabled NOTIFY ConcatScreenEnabledChanged)
     bool isConcatScreenEnabled();
-    QString concatScreenName();
+    QStringList ListEffectiveOutputNames();
 
 public Q_SLOTS:
     QStringList ListOutputNames();
@@ -64,6 +65,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void PrimaryChanged(const QString &Primary);
     void MonitorsChanged(QList<QDBusObjectPath> monitors);
+    void ConcatScreenEnabledChanged(bool isCancat);
 
     // xSettingsInterface
 public Q_SLOTS:

--- a/src/service/impl/appearancemanager.cpp
+++ b/src/service/impl/appearancemanager.cpp
@@ -93,6 +93,9 @@ bool AppearanceManager::init()
 
     connect(m_dbusProxy.get(), &AppearanceDBusProxy::PrimaryChanged, this, &AppearanceManager::updateMonitorMap);
     connect(m_dbusProxy.get(), &AppearanceDBusProxy::MonitorsChanged, this, &AppearanceManager::updateMonitorMap);
+    connect(m_dbusProxy.get(), &AppearanceDBusProxy::ConcatScreenEnabledChanged, this, [this](bool){
+        doUpdateWallpaperURIs();
+    });
 
     updateMonitorMap();
 
@@ -761,40 +764,29 @@ void AppearanceManager::doUpdateWallpaperURIs()
 {
     QMap<QString, QString> monitorWallpaperUris;
 
-    QStringList monitorList = m_dbusProxy->ListOutputNames();
+    const QStringList effectiveOutputs = m_dbusProxy->ListEffectiveOutputNames();
+    const QStringList monitorList = m_dbusProxy->ListOutputNames();
 
     QString key;
     const auto workspaceCount = getWorkspaceCount();
-    for (int i = 0; i < monitorList.length(); i++) {
+    for (const QString &outputName : effectiveOutputs) {
         for (int idx = 1; idx <= workspaceCount; idx++) {
-            const QString wallpaperUri = getWallpaperUri(QString::number(idx), monitorList.at(i));
+            const QString wallpaperUri = getWallpaperUri(QString::number(idx), outputName);
             if (wallpaperUri.isEmpty())
                 continue;
 
-            if (m_monitorMap.count(monitorList[i]) != 0) {
-                key = QString::asprintf("%s&&%d", m_monitorMap[monitorList[i]].toLatin1().data(), idx);
+            if (m_monitorMap.contains(outputName)) {
+                // physical screen in m_monitorMap cache, role known (Primary/SubsidiaryN)
+                key = m_monitorMap.value(outputName);
+            } else if (monitorList.contains(outputName)) {
+                // physical screen not in m_monitorMap cache, role unknown, "&&idx"
+                key = "";
             } else {
-                key = QString::asprintf("&&%d", idx);
+                // not in any physical screen list, may be virtual screen, use its name as role
+                key = outputName;
             }
-
+            key = QString("%1&&%2").arg(key).arg(idx);
             monitorWallpaperUris[key] = wallpaperUri;
-        }
-    }
-
-    // 跨屏拼接模式：DDE-CONCAT-SCREEN 是一个虚拟 RANDR Monitor，不在 ListOutputNames()
-    // 返回的物理显示器列表中。当拼接模式激活时，需将其壁纸也纳入 WallpaperURls，
-    // 确保 WM 合成器等订阅方能通过 PropertiesChanged 信号感知拼接屏的壁纸变更。
-    if (m_dbusProxy->isConcatScreenEnabled()) {
-        const QString concatScreenName = m_dbusProxy->concatScreenName();
-        if (!concatScreenName.isEmpty()) {
-            for (int idx = 1; idx <= workspaceCount; idx++) {
-                const QString wallpaperUri = getWallpaperUri(QString::number(idx), concatScreenName);
-                if (wallpaperUri.isEmpty())
-                    continue;
-
-                key = QString("%1&&%2").arg(concatScreenName).arg(idx);
-                monitorWallpaperUris[key] = wallpaperUri;
-            }
         }
     }
 


### PR DESCRIPTION
After toggling concat screen mode on/off, the WallpaperURls property is not rebuilt, causing the WallpaperPreviewItem thumbnail to not display in the personalization-wallpaper interface. Listen to ConcatScreenEnabledChanged to update WallpaperURls, and change the data source to ListEffectiveOutputNames, which includes both physical and virtual screens.

关闭/开启跨屏拼接后，未重建 WallpaperURls 属性，个性化-壁纸界面 WallpaperPreviewItem 缩略图不显示 监听 ConcatScreenEnabledChanged 更新 WallpaperURls，同时数据源改为 ListEffectiveOutputNames，包含物理屏和虚拟屏

Log: 监听 ConcatScreenEnabledChanged 更新 WallpaperURls 属性防止缩略图不显示
Influence: 个性化-壁纸，预览正确显示，切换壁纸正常；开启/关闭跨屏拼接，预览正确显示，切换壁纸正常；