### PR TITLE
fix: change cross-app accessed dconfig items from private to public

### DIFF
--- a/misc/dconfig/org.deepin.dde.appearance.json
+++ b/misc/dconfig/org.deepin.dde.appearance.json
@@ -34,13 +34,13 @@
         },
         "Wallpaper_Slideshow": {
             "value": "",
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Wallpaper_Slideshow",
             "name[zh_CN]": "*****",
             "description": "",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "Cursor_Theme": {
             "value": "bloom",
@@ -64,13 +64,13 @@
         },
         "Wallpaper_Uris": {
             "value": "",
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Wallpaper_Uris",
             "name[zh_CN]": "*****",
             "description": "current wallpaper json string",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "Icon_Theme": {
             "value": "nirvana",
@@ -84,13 +84,13 @@
         },
         "Global_Theme": {
             "value": "nirvana.light",
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Global_Theme",
             "name[zh_CN]": "*****",
             "description": "deepin theme to use for the panel, nautilus etc.",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "Opacity": {
             "value": 0.40000000000000002,
@@ -134,23 +134,23 @@
         },
         "Sound_Theme": {
             "value": "deepin",
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Sound_Theme",
             "name[zh_CN]": "*****",
             "description": "Set the system sound theme",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "Background_Uris": {
             "value": ["file:///usr/share/backgrounds/default_background.jpg"],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Background_Uris",
             "name[zh_CN]": "*****",
             "description": "Note that the backend only supports local (file://) URIs.",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "All_Wallpaper_Uris": {
             "value": [],


### PR DESCRIPTION
fix: change cross-app accessed dconfig items from private to public

## 变更说明
- 将 dde-appearance 中跨应用可访问的 dconfig 配置项权限由 private 改为 public
- 这些配置项会被多个 app 使用，私有权限会导致其他应用读取失败

## 具体修改的配置项
- [dde-appearance 配置项列表](#)

## 技术方案简述
- 运用〖限制_AM_Identity〗接口（QDBusMethod）
- setErrorQDBusInterface on dde-dconfig-daemon
- cross-bus: AMIdentity::fingerprint = "org.deepin.dde.appearance"
- fallback: AMIdentity::fingerprint = getProcessNameByPid(pid) || getUidByPid(uid)

## 关联的其他 PR
- dde-daemon: https://github.com/linuxdeepin/dde-daemon/pull/1184
- dde-shell: https://github.com/linuxdeepin/dde-shell/pull/...
- dde-app-services: https://github.com/linuxdeepin/dde-app-services/pull/...

## Summary by Sourcery

Bug Fixes:
- Fix cross-application read failures caused by dde-appearance dconfig items being marked as private instead of public.